### PR TITLE
Add support for Anthropic Model from AWS Bedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pip install askui
 
 |  | AskUI [INFO](https://app.askui.com/) | Anthropic [INFO](https://console.anthropic.com/settings/keys) |
 |----------|----------|----------|
-| ENV Variables    | `ASKUI_WORKSPACE_ID`, `ASKUI_TOKEN`   | `ANTHROPIC_API_KEY`   |
+| ENV Variables    | `ASKUI_WORKSPACE_ID`, `ASKUI_TOKEN`   | `ANTHROPIC_API_KEY`/`ANTHROPIC_BEDROCK_PROFILE`   |
 | Supported Commands    | `click()`   | `click()`, `get()`, `act()`   |
 | Description    | Faster Inference, European Server, Enterprise Ready   | Supports complex actions   |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pillow>=11.0.0",
     "pydantic>=2.9.2",
     "anthropic>=0.37.1",
+    "anthropic[bedrock]>=0.43.1",
     "rich>=13.9.4",
     "pyperclip>=1.9.0",
     "gradio-client>=1.4.3",

--- a/src/askui/models/anthropic/claude.py
+++ b/src/askui/models/anthropic/claude.py
@@ -1,21 +1,20 @@
-import os
 import anthropic
 from PIL import Image
 
 from ...logging import logger
 from ...utils import AutomationError
 from ..utils import scale_image_with_padding, scale_coordinates_back, extract_click_coordinates, image_to_base64
-
+from .claude_provider import ClaudeApiProvider
 
 class ClaudeHandler:
     def __init__(self, log_level):
-        self.model_name = "claude-3-5-sonnet-20241022"
-        self.client = anthropic.Anthropic()
+        claude_api_provider = ClaudeApiProvider()
+        self.client = claude_api_provider.get_api_client()
+        self.model_name = claude_api_provider.get_model_name()
+
         self.resolution = (1280, 800)
         self.log_level = log_level
-        self.authenticated = True
-        if os.getenv("ANTHROPIC_API_KEY") is None:
-            self.authenticated = False
+
 
     def inference(self, base64_image, prompt, system_prompt) -> list[anthropic.types.ContentBlock]:
         message = self.client.messages.create(

--- a/src/askui/models/anthropic/claude_agent.py
+++ b/src/askui/models/anthropic/claude_agent.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import Any, cast, Literal
 
 from anthropic import (
-    Anthropic,
     APIError,
     APIResponseValidationError,
     APIStatusError,
@@ -24,6 +23,7 @@ from ...tools.anthropic import ComputerTool, ToolCollection, ToolResult
 from ...logging import logger
 from ...utils import truncate_long_strings
 from askui.reporting.report import SimpleReportGenerator
+from askui.models.anthropic.claude_provider import ClaudeApiProvider
 
 
 COMPUTER_USE_BETA_FLAG = "computer-use-2024-10-22"
@@ -31,17 +31,6 @@ PROMPT_CACHING_BETA_FLAG = "prompt-caching-2024-07-31"
 PC_KEY = Literal['backspace', 'delete', 'enter', 'tab', 'escape', 'up', 'down', 'right', 'left', 'home', 'end', 'pageup', 'pagedown', 'f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10', 'f11', 'f12', 'space', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~']
 
 
-# class APIProvider(StrEnum):
-#     ANTHROPIC = "anthropic"
-#     BEDROCK = "bedrock"
-#     VERTEX = "vertex"
-
-
-# PROVIDER_TO_DEFAULT_MODEL_NAME: dict[APIProvider, str] = {
-#     APIProvider.ANTHROPIC: "claude-3-5-sonnet-20241022",
-#     APIProvider.BEDROCK: "anthropic.claude-3-5-sonnet-20241022-v2:0",
-#     APIProvider.VERTEX: "claude-3-5-sonnet-v2@20241022",
-# }
 
 
 SYSTEM_PROMPT = f"""<SYSTEM_CAPABILITY>
@@ -74,8 +63,10 @@ class ClaudeComputerAgent:
         self.image_truncation_threshold = 10
         self.only_n_most_recent_images = 3
         self.max_tokens = 4096
-        self.client = Anthropic()
-        self.model = "claude-3-5-sonnet-20241022"
+
+        claude_api_provider = ClaudeApiProvider()
+        self.client = claude_api_provider.get_api_client()
+        self.model = claude_api_provider.get_model_name()
 
     def step(self, messages: list):
         if self.only_n_most_recent_images:

--- a/src/askui/models/anthropic/claude_provider.py
+++ b/src/askui/models/anthropic/claude_provider.py
@@ -1,0 +1,53 @@
+import os
+from anthropic import AnthropicBedrock, Anthropic
+from enum import StrEnum
+from ...logging import logger
+
+
+class APIProvider(StrEnum):
+    ANTHROPIC = "anthropic"
+    BEDROCK = "bedrock"
+    # VERTEX = "vertex"
+
+
+PROVIDER_TO_DEFAULT_MODEL_NAME: dict[APIProvider, str] = {
+    APIProvider.ANTHROPIC: "claude-3-5-sonnet-20241022",
+    APIProvider.BEDROCK: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    # APIProvider.VERTEX: "claude-3-5-sonnet-v2@20241022",
+}
+
+
+class ClaudeApiProvider:
+    api_provider: APIProvider
+    api_client: AnthropicBedrock | Anthropic | None
+
+    def __init__(self):
+        anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+        anthropic_bedrock_profile = os.getenv("ANTHROPIC_BEDROCK_PROFILE")
+
+        self.api_provider = None
+        self.api_client = None
+
+        if anthropic_api_key:
+            self.api_provider = APIProvider.ANTHROPIC
+            self.api_client = Anthropic()
+            logger.info("ANTHROPIC_API_KEY is set, using Anthropic API provider.")
+        elif anthropic_bedrock_profile:
+            self.api_provider = APIProvider.BEDROCK
+            self.api_client = AnthropicBedrock(
+                aws_profile=anthropic_bedrock_profile,
+            )
+            logger.info("ANTHROPIC_BEDROCK_PROFILE is set, using Anthropic Bedrock API provider.")
+        else:
+            raise ValueError("ANTHROPIC_API_KEY or ANTHROPIC_BEDROCK_PROFILE must be set")
+
+        self.model = PROVIDER_TO_DEFAULT_MODEL_NAME[self.api_provider]
+
+    def get_model_name(self):
+        return self.model
+
+    def get_api_client(self):
+        return self.api_client
+
+    def get_api_provider(self):
+        return self.api_provider


### PR DESCRIPTION
Closes #18

The following pull request add support for AWS bedrock provider. Clients can now either set `ANTHROPIC_BEDROCK_PROFILE` or `ANTHROPIC_API_KEY`.