### PR TITLE
Fix routing & blocking telemetry

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
             cache: true
       - run: pdm install
-      - run: pdm run typecheck:all
       - run: pdm run format --check
-      - run: pdm run lint
+      - run: pdm run typecheck:all
+      - run: pdm run lint --output-format=github
       - run: pdm run test:unit

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        
+        {
+            "name": "Debug Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": [
+                "-vv",
+            ],
+            "console": "integratedTerminal"
+        },
+    ]
+}

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "chat", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:ee418ee4c04af70fff91a2b30c650ad1d04eb5e4bb4a1cbb47c2f43a1327a1cc"
+content_hash = "sha256:fc9c6d1e6e03e722cea57c2a4ede898373b6ca551e8ab76321688873b5325d2d"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -1433,6 +1433,20 @@ dependencies = [
 files = [
     {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
     {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+requires_python = ">=3.7"
+summary = "pytest plugin to abort hanging tests"
+groups = ["test"]
+dependencies = [
+    "pytest>=7.0.0",
+]
+files = [
+    {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
+    {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ test = [
     "types-protobuf>=4.24.0.20240311",
     "grpc-stubs>=1.53.0.3",
     "types-pyperclip>=1.8.2.20240311",
+    "pytest-timeout>=2.4.0",
 ]
 chat = [
     "streamlit>=1.42.0",

--- a/src/askui/agent.py
+++ b/src/askui/agent.py
@@ -135,6 +135,7 @@ class VisionAgent:
         self._reporter.add_message("ModelRouter", f"locate: ({point[0]}, {point[1]})")
         return point
 
+    @telemetry.record_call(exclude={"locator", "screenshot"})
     @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def locate(
         self,

--- a/src/askui/agent.py
+++ b/src/askui/agent.py
@@ -476,13 +476,15 @@ class VisionAgent:
         self,
         key: PcKey | ModifierKey,
         modifier_keys: Optional[list[ModifierKey]] = None,
+        repeat: Annotated[int, Field(gt=0)] = 1,
     ) -> None:
         """
-        Simulates pressing a key or key combination on the keyboard.
+        Simulates pressing (and releasing) a key or key combination on the keyboard.
 
         Args:
             key (PcKey | ModifierKey): The main key to press. This can be a letter, number, special character, or function key.
             modifier_keys (list[ModifierKey] | None, optional): List of modifier keys to press along with the main key. Common modifier keys include `'ctrl'`, `'alt'`, `'shift'`.
+            repeat (int, optional): The number of times to press (and release) the key. Must be greater than `0`. Defaults to `1`.
 
         Example:
             ```python
@@ -493,10 +495,18 @@ class VisionAgent:
                 agent.keyboard('enter')  # Press 'Enter' key
                 agent.keyboard('v', ['control'])  # Press Ctrl+V (paste)
                 agent.keyboard('s', ['control', 'shift'])  # Press Ctrl+Shift+S
+                agent.keyboard('a', repeat=2)  # Press 'a' key twice
             ```
         """
+        msg = f"press and release key '{key}'"
+        if modifier_keys is not None:
+            modifier_keys_str = ' + '.join(f"'{key}'" for key in modifier_keys)
+            msg += f" with modifiers key{'s' if len(modifier_keys) > 1 else ''} {modifier_keys_str}"
+        if repeat > 1:
+            msg += f" {repeat}x times"
+        self._reporter.add_message("User", msg)
         logger.debug("VisionAgent received instruction to press '%s'", key)
-        self.tools.agent_os.keyboard_tap(key, modifier_keys)
+        self.tools.agent_os.keyboard_tap(key, modifier_keys, count=repeat)
 
     @telemetry.record_call(exclude={"command"})
     @validate_call

--- a/src/askui/models/anthropic/settings.py
+++ b/src/askui/models/anthropic/settings.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel, Field, SecretStr
+from pydantic_settings import BaseSettings
+
+COMPUTER_USE_BETA_FLAG = "computer-use-2024-10-22"
+
+
+class AnthropicSettings(BaseSettings):
+    api_key: SecretStr = Field(
+        min_length=1,
+        validation_alias="ANTHROPIC_API_KEY",
+    )
+
+
+class ClaudeSettingsBase(BaseModel):
+    anthropic: AnthropicSettings = Field(default_factory=AnthropicSettings)
+    model: str = "claude-3-5-sonnet-20241022"
+
+
+class ClaudeSettings(ClaudeSettingsBase):
+    resolution: tuple[int, int] = Field(default_factory=lambda: (1280, 800))
+    max_tokens: int = 1000
+    temperature: float = 0.0
+
+
+class ClaudeComputerAgentSettings(ClaudeSettingsBase):
+    max_tokens: int = 4096
+    only_n_most_recent_images: int = 3
+    image_truncation_threshold: int = 10
+    betas: list[str] = Field(default_factory=lambda: [COMPUTER_USE_BETA_FLAG])

--- a/src/askui/models/exceptions.py
+++ b/src/askui/models/exceptions.py
@@ -1,0 +1,15 @@
+from askui.exceptions import AutomationError
+from askui.models.models import ModelComposition
+
+
+class InvalidModelError(AutomationError):
+    """Exception raised when an invalid model is used.
+
+    Args:
+        model (str | ModelComposition): The model that was used.
+    """
+
+    def __init__(self, model: str | ModelComposition):
+        self.model = model
+        model_str = model if isinstance(model, str) else model.model_dump_json()
+        super().__init__(f"Invalid model: {model_str}")

--- a/src/askui/models/models.py
+++ b/src/askui/models/models.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 class ModelName(str, Enum):
     ANTHROPIC__CLAUDE__3_5__SONNET__20241022 = "anthropic-claude-3-5-sonnet-20241022"
-    ANTHROPIC = "anthropic"
     ASKUI = "askui"
     ASKUI__AI_ELEMENT = "askui-ai-element"
     ASKUI__COMBO = "askui-combo"

--- a/src/askui/models/router.py
+++ b/src/askui/models/router.py
@@ -291,9 +291,7 @@ class ModelRouter:
                 screenshot, self._serialize_locator(locator)
             )
             return handle_response(point, locator)
-        point = self._try_locating_using_grounding_model(
-            screenshot, locator, model
-        )
+        point = self._try_locating_using_grounding_model(screenshot, locator, model)
         if point:
             return handle_response(point, locator)
         if not point and model is None:

--- a/src/askui/telemetry/telemetry.py
+++ b/src/askui/telemetry/telemetry.py
@@ -96,8 +96,22 @@ class Telemetry:
         self._call_stack = CallStack()
         self._context = self._init_context()
 
+    def set_processors(self, processors: list[TelemetryProcessor]) -> None:
+        """Set the telemetry processors that will be called in order
+
+        *IMPORTANT*: This will replace the existing processors.
+
+        Args:
+            processors (list[TelemetryProcessor]): The list of telemetry processors to set (may be empty)
+        """
+        self._processors = processors
+
     def add_processor(self, processor: TelemetryProcessor) -> None:
-        """Add a telemetry processor that will be called in order of addition"""
+        """Add a telemetry processor that will be called in order of addition
+
+        Args:
+            processor (TelemetryProcessor): The telemetry processor to add
+        """
         self._processors.append(processor)
 
     def _init_context(self) -> TelemetryContext:

--- a/src/askui/tools/agent_os.py
+++ b/src/askui/tools/agent_os.py
@@ -276,7 +276,10 @@ class AgentOs(ABC):
 
     @abstractmethod
     def keyboard_tap(
-        self, key: PcKey | ModifierKey, modifier_keys: list[ModifierKey] | None = None
+        self,
+        key: PcKey | ModifierKey,
+        modifier_keys: list[ModifierKey] | None = None,
+        count: int = 1,
     ) -> None:
         """
         Simulates pressing and immediately releasing a keyboard key.
@@ -285,6 +288,7 @@ class AgentOs(ABC):
             key (PcKey | ModifierKey): The key to tap.
             modifier_keys (list[ModifierKey] | None, optional): List of modifier keys to
                 press along with the main key. Defaults to `None`.
+            count (int, optional): The number of times to tap the key. Defaults to `1`.
         """
         raise NotImplementedError
 

--- a/src/askui/tools/askui/askui_controller.py
+++ b/src/askui/tools/askui/askui_controller.py
@@ -648,7 +648,10 @@ class AskUiControllerClient(AgentOs):
     @telemetry.record_call()
     @override
     def keyboard_tap(
-        self, key: PcKey | ModifierKey, modifier_keys: list[ModifierKey] | None = None
+        self,
+        key: PcKey | ModifierKey,
+        modifier_keys: list[ModifierKey] | None = None,
+        count: int = 1,
     ) -> None:
         """
         Press and immediately release a keyboard key.
@@ -657,18 +660,23 @@ class AskUiControllerClient(AgentOs):
             key (PcKey | ModifierKey): The key to tap.
             modifier_keys (list[ModifierKey] | None, optional): List of modifier keys to
                 press along with the main key. Defaults to `None`.
+            count (int, optional): The number of times to tap the key. Defaults to `1`.
         """
-        self._reporter.add_message("AgentOS", f'keyboard_tap("{key}", {modifier_keys})')
+        self._reporter.add_message(
+            "AgentOS",
+            f'keyboard_tap("{key}", {modifier_keys}, {count})',
+        )
         if modifier_keys is None:
             modifier_keys = []
-        self._run_recorder_action(
-            acion_class_id=controller_v1_pbs.ActionClassID_KeyboardKey_PressAndRelease,
-            action_parameters=controller_v1_pbs.ActionParameters(
-                keyboardKeyPressAndRelease=controller_v1_pbs.ActionParameters_KeyboardKey_PressAndRelease(
-                    keyName=key, modifierKeyNames=modifier_keys
-                )
-            ),
-        )
+        for _ in range(count):
+            self._run_recorder_action(
+                    acion_class_id=controller_v1_pbs.ActionClassID_KeyboardKey_PressAndRelease,
+                    action_parameters=controller_v1_pbs.ActionParameters(
+                    keyboardKeyPressAndRelease=controller_v1_pbs.ActionParameters_KeyboardKey_PressAndRelease(
+                        keyName=key, modifierKeyNames=modifier_keys
+                    )
+                ),
+            )
 
     @telemetry.record_call()
     @override

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,15 @@ def path_fixtures_images(path_fixtures: pathlib.Path) -> pathlib.Path:
 
 
 @pytest.fixture
+def github_login_screenshot(path_fixtures: pathlib.Path) -> Image.Image:
+    """Fixture providing the GitHub login screenshot."""
+    screenshot_path = (
+        path_fixtures / "screenshots" / "macos__chrome__github_com__login.png"
+    )
+    return Image.open(screenshot_path)
+
+
+@pytest.fixture
 def path_fixtures_github_com__icon(path_fixtures_images: pathlib.Path) -> pathlib.Path:
     """Fixture providing the path to the github com icon image."""
     return path_fixtures_images / "github_com__icon.png"
@@ -51,3 +60,10 @@ def model_router_mock(mocker: MockerFixture) -> ModelRouter:
         "Mock response"  # Return fixed response for all get_inference calls
     )
     return cast("ModelRouter", mock)
+
+
+@pytest.fixture(autouse=True)
+def disable_telemetry() -> None:
+    from askui.container import telemetry
+
+    telemetry.set_processors([])

--- a/tests/e2e/agent/conftest.py
+++ b/tests/e2e/agent/conftest.py
@@ -10,7 +10,7 @@ from typing_extensions import override
 from askui.agent import VisionAgent
 from askui.locators.serializers import AskUiLocatorSerializer
 from askui.models.askui.ai_element_utils import AiElementCollection
-from askui.models.askui.api import AskUiInferenceApi
+from askui.models.askui.api import AskUiInferenceApi, AskUiSettings
 from askui.models.router import AskUiModelRouter, ModelRouter
 from askui.reporting import Reporter, SimpleHtmlReporter
 from askui.tools.toolbox import AgentToolbox
@@ -43,7 +43,10 @@ def vision_agent(
     serializer = AskUiLocatorSerializer(
         ai_element_collection=ai_element_collection, reporter=reporter
     )
-    inference_api = AskUiInferenceApi(locator_serializer=serializer)
+    inference_api = AskUiInferenceApi(
+        locator_serializer=serializer,
+        settings=AskUiSettings(),
+    )
     model_router = ModelRouter(
         tools=agent_toolbox_mock,
         reporter=reporter,

--- a/tests/e2e/agent/conftest.py
+++ b/tests/e2e/agent/conftest.py
@@ -56,12 +56,3 @@ def vision_agent(
         reporters=[reporter], model_router=model_router, tools=agent_toolbox_mock
     ) as agent:
         yield agent
-
-
-@pytest.fixture
-def github_login_screenshot(path_fixtures: pathlib.Path) -> PILImage.Image:
-    """Fixture providing the GitHub login screenshot."""
-    screenshot_path = (
-        path_fixtures / "screenshots" / "macos__chrome__github_com__login.png"
-    )
-    return PILImage.open(screenshot_path)

--- a/tests/e2e/agent/test_get.py
+++ b/tests/e2e/agent/test_get.py
@@ -20,7 +20,7 @@ class BrowserContextResponse(ResponseSchemaBase):
     browser_type: Literal["chrome", "firefox", "edge", "safari"]
 
 
-@pytest.mark.parametrize("model", [None, ModelName.ASKUI, ModelName.ANTHROPIC])
+@pytest.mark.parametrize("model", [None, ModelName.ASKUI, ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022])
 def test_get(
     vision_agent: VisionAgent,
     github_login_screenshot: PILImage.Image,
@@ -91,7 +91,7 @@ def test_get_with_response_schema_with_anthropic_model_raises_not_implemented(
             "What is the current url shown in the url bar?",
             image=github_login_screenshot,
             response_schema=UrlResponse,
-            model=ModelName.ANTHROPIC,
+            model=ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022,
         )
 
 

--- a/tests/e2e/agent/test_get.py
+++ b/tests/e2e/agent/test_get.py
@@ -20,7 +20,9 @@ class BrowserContextResponse(ResponseSchemaBase):
     browser_type: Literal["chrome", "firefox", "edge", "safari"]
 
 
-@pytest.mark.parametrize("model", [None, ModelName.ASKUI, ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022])
+@pytest.mark.parametrize(
+    "model", [None, ModelName.ASKUI, ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022]
+)
 def test_get(
     vision_agent: VisionAgent,
     github_login_screenshot: PILImage.Image,

--- a/tests/e2e/test_telemetry.py
+++ b/tests/e2e/test_telemetry.py
@@ -1,0 +1,30 @@
+import logging
+
+import pytest
+from PIL import Image
+
+from askui import locators as loc
+from askui.agent import VisionAgent
+from askui.container import telemetry
+from askui.telemetry.processors import Segment, SegmentSettings
+from askui.tools.toolbox import AgentToolbox
+
+
+@pytest.mark.timeout(60)
+def test_telemetry_with_nonexistent_domain_should_not_block(
+    github_login_screenshot: Image.Image,
+    agent_toolbox_mock: AgentToolbox,
+) -> None:
+    telemetry.set_processors(
+        [
+            Segment(
+                SegmentSettings(
+                    api_url="https://this-domain-does-not-exist-123456789.com",
+                    write_key="1234567890",
+                )
+            )
+        ]
+    )
+    with VisionAgent(tools=agent_toolbox_mock, log_level=logging.DEBUG) as agent:
+        agent.locate(loc.Text(), screenshot=github_login_screenshot)
+    assert True

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,5 +3,4 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def set_env_variable(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ASKUI__VA__TELEMETRY__ENABLED", "False")
     monkeypatch.setenv("ASKUI_WORKSPACE_ID", "test_workspace_id")

--- a/tests/unit/models/test_router.py
+++ b/tests/unit/models/test_router.py
@@ -1,0 +1,422 @@
+"""Unit tests for the ModelRouter class."""
+
+import os
+import uuid
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+from pydantic import ValidationError
+from pytest_mock import MockerFixture
+
+from askui.models.anthropic.claude import ClaudeHandler
+from askui.models.anthropic.claude_agent import ClaudeComputerAgent
+from askui.models.askui.api import AskUiInferenceApi
+from askui.models.exceptions import InvalidModelError
+from askui.models.huggingface.spaces_api import HFSpacesHandler
+from askui.models.models import ModelName
+from askui.models.router import ModelRouter
+from askui.models.types.response_schemas import ResponseSchemaBase
+from askui.models.ui_tars_ep.ui_tars_api import UiTarsApiHandler
+from askui.reporting import CompositeReporter
+from askui.tools.toolbox import AgentToolbox
+from askui.utils.image_utils import ImageSource
+
+# Test UUID for workspace_id
+TEST_WORKSPACE_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def mock_image() -> Image.Image:
+    """Fixture providing a mock PIL Image."""
+    return Image.new("RGB", (100, 100))
+
+
+@pytest.fixture
+def mock_image_source(mock_image: Image.Image) -> ImageSource:
+    """Fixture providing a mock ImageSource."""
+    return ImageSource(root=mock_image)
+
+
+@pytest.fixture
+def mock_askui_inference_api(mocker: MockerFixture) -> AskUiInferenceApi:
+    """Fixture providing a mock AskUI inference API."""
+    mock = cast("AskUiInferenceApi", mocker.MagicMock(spec=AskUiInferenceApi))
+    mock.predict.return_value = (50, 50)  # type: ignore[attr-defined]
+    mock.get_inference.return_value = "Mock response"  # type: ignore[attr-defined]
+    return mock
+
+
+@pytest.fixture
+def mock_claude(mocker: MockerFixture) -> ClaudeHandler:
+    """Fixture providing a mock Claude handler."""
+    mock = cast("ClaudeHandler", mocker.MagicMock(spec=ClaudeHandler))
+    mock.locate_inference.return_value = (50, 50)  # type: ignore[attr-defined]
+    mock.get_inference.return_value = "Mock response"  # type: ignore[attr-defined]
+    return mock
+
+
+@pytest.fixture
+def mock_claude_agent(mocker: MockerFixture) -> ClaudeComputerAgent:
+    """Fixture providing a mock Claude computer agent."""
+    mock = cast("ClaudeComputerAgent", mocker.MagicMock(spec=ClaudeComputerAgent))
+    mock.act = MagicMock(return_value=None)  # type: ignore[method-assign]
+    return mock
+
+
+@pytest.fixture
+def mock_tars(mocker: MockerFixture) -> UiTarsApiHandler:
+    """Fixture providing a mock TARS API handler."""
+    mock = cast("UiTarsApiHandler", mocker.MagicMock(spec=UiTarsApiHandler))
+    mock.locate_prediction.return_value = (50, 50)  # type: ignore[attr-defined]
+    mock.get_inference.return_value = "Mock response"  # type: ignore[attr-defined]
+    mock.act = MagicMock(return_value=None)  # type: ignore[method-assign]
+    return mock
+
+
+@pytest.fixture
+def mock_hf_spaces(mocker: MockerFixture) -> HFSpacesHandler:
+    """Fixture providing a mock HuggingFace spaces handler."""
+    mock = cast("HFSpacesHandler", mocker.MagicMock(spec=HFSpacesHandler))
+    mock.predict.return_value = (50, 50)  # type: ignore[attr-defined]
+    mock.get_spaces_names.return_value = ["hf-space-1", "hf-space-2"]  # type: ignore[attr-defined]
+    return mock
+
+
+@pytest.fixture
+def model_router(
+    agent_toolbox_mock: AgentToolbox,
+    mock_askui_inference_api: AskUiInferenceApi,
+    mock_claude: ClaudeHandler,
+    mock_claude_agent: ClaudeComputerAgent,
+    mock_tars: UiTarsApiHandler,
+    mock_hf_spaces: HFSpacesHandler,
+    mocker: MockerFixture,
+) -> ModelRouter:
+    """Fixture providing a ModelRouter instance with mocked dependencies."""
+    return ModelRouter(
+        tools=agent_toolbox_mock,
+        reporter=CompositeReporter(),
+        askui_inference_api=mock_askui_inference_api,
+        claude=mock_claude,
+        claude_computer_agent=mock_claude_agent,
+        tars=mock_tars,
+        huggingface_spaces=mock_hf_spaces,
+        askui_settings=mocker.MagicMock(workspace_id=TEST_WORKSPACE_ID),
+    )
+
+
+class TestModelRouter:
+    """Test class for ModelRouter."""
+
+    def test_locate_with_askui_model(
+        self,
+        model_router: ModelRouter,
+        mock_image: Image.Image,
+        mock_askui_inference_api: AskUiInferenceApi,
+    ) -> None:
+        """Test locating elements using AskUI model."""
+        locator = "test locator"
+        x, y = model_router.locate(mock_image, locator, ModelName.ASKUI)
+        assert x == 50
+        assert y == 50
+        mock_askui_inference_api.predict.assert_called_once()  # type: ignore
+
+    def test_locate_with_askui_pta_model(
+        self,
+        model_router: ModelRouter,
+        mock_image: Image.Image,
+        mock_askui_inference_api: AskUiInferenceApi,
+    ) -> None:
+        """Test locating elements using AskUI PTA model."""
+        locator = "test locator"
+        x, y = model_router.locate(mock_image, locator, ModelName.ASKUI__PTA)
+        assert x == 50
+        assert y == 50
+        mock_askui_inference_api.predict.assert_called_once()  # type: ignore
+
+    def test_locate_with_askui_ocr_model(
+        self,
+        model_router: ModelRouter,
+        mock_image: Image.Image,
+        mock_askui_inference_api: AskUiInferenceApi,
+    ) -> None:
+        """Test locating elements using AskUI OCR model."""
+        locator = "test locator"
+        x, y = model_router.locate(mock_image, locator, ModelName.ASKUI__OCR)
+        assert x == 50
+        assert y == 50
+        mock_askui_inference_api.predict.assert_called_once()  # type: ignore
+
+    def test_locate_with_askui_combo_model(
+        self,
+        model_router: ModelRouter,
+        mock_image: Image.Image,
+        mock_askui_inference_api: AskUiInferenceApi,
+    ) -> None:
+        """Test locating elements using AskUI combo model."""
+        locator = "test locator"
+        x, y = model_router.locate(mock_image, locator, ModelName.ASKUI__COMBO)
+        assert x == 50
+        assert y == 50
+        mock_askui_inference_api.predict.assert_called_once()  # type: ignore
+
+    def test_locate_with_askui_ai_element_model(
+        self,
+        model_router: ModelRouter,
+        mock_image: Image.Image,
+        mock_askui_inference_api: AskUiInferenceApi,
+    ) -> None:
+        """Test locating elements using AskUI AI element model."""
+        locator = "test locator"
+        x, y = model_router.locate(mock_image, locator, ModelName.ASKUI__AI_ELEMENT)
+        assert x == 50
+        assert y == 50
+        mock_askui_inference_api.predict.assert_called_once()  # type: ignore
+
+    def test_locate_with_tars_model(
+        self,
+        model_router: ModelRouter,
+        mock_image: Image.Image,
+        mock_tars: UiTarsApiHandler,
+    ) -> None:
+        """Test locating elements using TARS model."""
+        locator = "test locator"
+        x, y = model_router.locate(mock_image, locator, ModelName.TARS)
+        assert x == 50
+        assert y == 50
+        mock_tars.locate_prediction.assert_called_once()  # type: ignore
+
+    def test_locate_with_claude_model(
+        self,
+        model_router: ModelRouter,
+        mock_image: Image.Image,
+        mock_claude: ClaudeHandler,
+    ) -> None:
+        """Test locating elements using Claude model."""
+        locator = "test locator"
+        x, y = model_router.locate(
+            mock_image, locator, ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022
+        )
+        assert x == 50
+        assert y == 50
+        mock_claude.locate_inference.assert_called_once()  # type: ignore
+
+    def test_locate_with_hf_space_model(
+        self,
+        model_router: ModelRouter,
+        mock_image: Image.Image,
+        mock_hf_spaces: HFSpacesHandler,
+    ) -> None:
+        """Test locating elements using HuggingFace space model."""
+        locator = "test locator"
+        x, y = model_router.locate(mock_image, locator, "hf-space-1")
+        assert x == 50
+        assert y == 50
+        mock_hf_spaces.predict.assert_called_once()  # type: ignore
+
+    def test_locate_with_invalid_model(
+        self, model_router: ModelRouter, mock_image: Image.Image
+    ) -> None:
+        """Test that locating with invalid model raises InvalidModelError."""
+        with pytest.raises(InvalidModelError):
+            model_router.locate(mock_image, "test locator", "invalid-model")
+
+    def test_get_inference_with_askui_model(
+        self,
+        model_router: ModelRouter,
+        mock_image_source: ImageSource,
+        mock_askui_inference_api: AskUiInferenceApi,
+    ) -> None:
+        """Test getting inference using AskUI model."""
+        response = model_router.get_inference(
+            "test query", mock_image_source, model=ModelName.ASKUI
+        )
+        assert response == "Mock response"
+        mock_askui_inference_api.get_inference.assert_called_once()  # type: ignore
+
+    def test_get_inference_with_tars_model(
+        self,
+        model_router: ModelRouter,
+        mock_image_source: ImageSource,
+        mock_tars: UiTarsApiHandler,
+    ) -> None:
+        """Test getting inference using TARS model."""
+        response = model_router.get_inference(
+            "test query", mock_image_source, model=ModelName.TARS
+        )
+        assert response == "Mock response"
+        mock_tars.get_inference.assert_called_once()  # type: ignore
+
+    def test_get_inference_with_claude_model(
+        self,
+        model_router: ModelRouter,
+        mock_image_source: ImageSource,
+        mock_claude: ClaudeHandler,
+    ) -> None:
+        """Test getting inference using Claude model."""
+        response = model_router.get_inference(
+            "test query",
+            mock_image_source,
+            model=ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022,
+        )
+        assert response == "Mock response"
+        mock_claude.get_inference.assert_called_once()  # type: ignore
+
+    def test_get_inference_with_invalid_model(
+        self, model_router: ModelRouter, mock_image_source: ImageSource
+    ) -> None:
+        """Test that getting inference with invalid model raises InvalidModelError."""
+        with pytest.raises(InvalidModelError):
+            model_router.get_inference(
+                "test query", mock_image_source, model="invalid-model"
+            )
+
+    def test_get_inference_with_response_schema_not_implemented(
+        self, model_router: ModelRouter, mock_image_source: ImageSource
+    ) -> None:
+        """
+        Test that getting inference with response schema for non-AskUI models raises
+        NotImplementedError.
+        """
+
+        class TestSchema(ResponseSchemaBase):
+            pass
+
+        with pytest.raises(NotImplementedError):
+            model_router.get_inference(
+                "test query",
+                mock_image_source,
+                response_schema=TestSchema,
+                model=ModelName.TARS,
+            )
+
+    def test_act_with_tars_model(
+        self, model_router: ModelRouter, mock_tars: UiTarsApiHandler
+    ) -> None:
+        """Test acting using TARS model."""
+        model_router.act("test goal", ModelName.TARS)
+        mock_tars.act.assert_called_once_with("test goal")  # type: ignore
+
+    def test_act_with_claude_model(
+        self, model_router: ModelRouter, mock_claude_agent: ClaudeComputerAgent
+    ) -> None:
+        """Test acting using Claude model."""
+        model_router.act(
+            "test goal", ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022
+        )
+        mock_claude_agent.act.assert_called_once_with("test goal")  # type: ignore
+
+    def test_act_with_invalid_model(self, model_router: ModelRouter) -> None:
+        """Test that acting with invalid model raises InvalidModelError."""
+        with pytest.raises(InvalidModelError):
+            model_router.act("test goal", "invalid-model")
+
+    def test_act_with_missing_anthropic_credentials(
+        self, model_router: ModelRouter
+    ) -> None:
+        """
+        Test that acting with Claude model raises ValidationError when credentials are
+        missing.
+        """
+        with patch.dict(os.environ, {}, clear=True):
+            router = ModelRouter(
+                tools=model_router._tools, reporter=model_router._reporter
+            )
+            with pytest.raises(ValidationError, match="ANTHROPIC_API_KEY"):
+                router.act(
+                    "test goal", ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022
+                )
+
+    def test_act_with_default_missing_credentials(
+        self, model_router: ModelRouter
+    ) -> None:
+        """
+        Test that acting with default model raises ValidationError when credentials are
+        missing.
+        """
+        with patch.dict(os.environ, {}, clear=True):
+            router = ModelRouter(
+                tools=model_router._tools, reporter=model_router._reporter
+            )
+            with pytest.raises(ValidationError, match="ANTHROPIC_API_KEY"):
+                router.act("test goal")
+
+    def test_locate_with_missing_askui_credentials(
+        self, model_router: ModelRouter, mock_image: Image.Image
+    ) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            router = ModelRouter(
+                tools=model_router._tools,
+                reporter=model_router._reporter,
+            )
+            with pytest.raises(ValueError, match="ASKUI_WORKSPACE_ID"):
+                router.locate(mock_image, "test locator", ModelName.ASKUI)
+
+    def test_locate_with_missing_askui_credentials_only_token(
+        self, model_router: ModelRouter, mock_image: Image.Image
+    ) -> None:
+        with patch.dict(
+            os.environ, {"ASKUI_WORKSPACE_ID": str(uuid.uuid4())}, clear=True
+        ):
+            router = ModelRouter(
+                tools=model_router._tools,
+                reporter=model_router._reporter,
+            )
+            with pytest.raises(ValueError, match="ASKUI_TOKEN"):
+                router.locate(mock_image, "test locator", ModelName.ASKUI)
+
+    def test_get_inference_with_missing_askui_credentials(
+        self,
+        model_router: ModelRouter,
+        mock_image_source: ImageSource,
+    ) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            router = ModelRouter(
+                tools=model_router._tools,
+                reporter=model_router._reporter,
+            )
+            with pytest.raises(ValueError, match="ASKUI_WORKSPACE_ID"):
+                router.get_inference(
+                    "test query", mock_image_source, model=ModelName.ASKUI
+                )
+
+    def test_get_inference_with_default_missing_credentials(
+        self,
+        model_router: ModelRouter,
+        mock_image_source: ImageSource,
+    ) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            router = ModelRouter(
+                tools=model_router._tools,
+                reporter=model_router._reporter,
+            )
+            with pytest.raises(ValueError, match="ASKUI_WORKSPACE_ID"):
+                router.get_inference("test query", mock_image_source)
+
+    def test_locate_with_missing_anthropic_credentials(
+        self, model_router: ModelRouter, mock_image: Image.Image
+    ) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            router = ModelRouter(
+                tools=model_router._tools,
+                reporter=model_router._reporter,
+            )
+            with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
+                router.locate(
+                    mock_image,
+                    "test locator",
+                    ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022,
+                )
+
+    def test_locate_with_default_missing_credentials(
+        self, model_router: ModelRouter, mock_image: Image.Image
+    ) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            router = ModelRouter(
+                tools=model_router._tools,
+                reporter=model_router._reporter,
+            )
+            with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
+                router.locate(mock_image, "test locator")


### PR DESCRIPTION
- ci(checks): run formatting before typechecking & use appropriate output formats
- fix(models): fix routing
  - raise `InvalidModelError` instead of missing credentials if
    model is not supported
  - raise `ValidationError` (missing credentials) if user
    specified model but credentials are missing instead of
    routing to different model using with credentials configured or
    raising invalid model error
  - raise `ValidationError` (missing credentials) if using default model
    but credentials are missing instead of raising invalid model error
  - intro custom `InvalidModelError` for unsupported models
  - expose underlying models of `ModelRouter` through constructor so
    consumers can override them (e.g. for testing)
  - make model clients, e.g., `ClaudeHandler`, `AskUiInferenceApi`, etc.
    more configurable moving their settings into `BaseSettings` subclass
    and exposing them through constructor
- fix(telemetry): unreachable segment (telemetry processor) url blocks test termination
  - track `VisionAgent.locate()`
  - fix url configuration for segment (url from settings not used)
  - fix test termination by using `shutdown` instead of `flush`,
    adding timeout and max retries
  - fix telemetry disabling in tests
  - allow resetting telemetry processors
  - add debugger config for tests