### PR TITLE
feat(agent): add repeat parameter to VisionAgent.keyboard()

### DIFF
--- a/src/askui/agent.py
+++ b/src/askui/agent.py
@@ -476,13 +476,15 @@ class VisionAgent:
         self,
         key: PcKey | ModifierKey,
         modifier_keys: Optional[list[ModifierKey]] = None,
+        repeat: Annotated[int, Field(gt=0)] = 1,
     ) -> None:
         """
-        Simulates pressing a key or key combination on the keyboard.
+        Simulates pressing (and releasing) a key or key combination on the keyboard.
 
         Args:
             key (PcKey | ModifierKey): The main key to press. This can be a letter, number, special character, or function key.
             modifier_keys (list[ModifierKey] | None, optional): List of modifier keys to press along with the main key. Common modifier keys include `'ctrl'`, `'alt'`, `'shift'`.
+            repeat (int, optional): The number of times to press (and release) the key. Must be greater than `0`. Defaults to `1`.
 
         Example:
             ```python
@@ -493,10 +495,18 @@ class VisionAgent:
                 agent.keyboard('enter')  # Press 'Enter' key
                 agent.keyboard('v', ['control'])  # Press Ctrl+V (paste)
                 agent.keyboard('s', ['control', 'shift'])  # Press Ctrl+Shift+S
+                agent.keyboard('a', repeat=2)  # Press 'a' key twice
             ```
         """
+        msg = f"press and release key '{key}'"
+        if modifier_keys is not None:
+            modifier_keys_str = ' + '.join(f"'{key}'" for key in modifier_keys)
+            msg += f" with modifiers key{'s' if len(modifier_keys) > 1 else ''} {modifier_keys_str}"
+        if repeat > 1:
+            msg += f" {repeat}x times"
+        self._reporter.add_message("User", msg)
         logger.debug("VisionAgent received instruction to press '%s'", key)
-        self.tools.agent_os.keyboard_tap(key, modifier_keys)
+        self.tools.agent_os.keyboard_tap(key, modifier_keys, count=repeat)
 
     @telemetry.record_call(exclude={"command"})
     @validate_call

--- a/src/askui/tools/agent_os.py
+++ b/src/askui/tools/agent_os.py
@@ -276,7 +276,10 @@ class AgentOs(ABC):
 
     @abstractmethod
     def keyboard_tap(
-        self, key: PcKey | ModifierKey, modifier_keys: list[ModifierKey] | None = None
+        self,
+        key: PcKey | ModifierKey,
+        modifier_keys: list[ModifierKey] | None = None,
+        count: int = 1,
     ) -> None:
         """
         Simulates pressing and immediately releasing a keyboard key.
@@ -285,6 +288,7 @@ class AgentOs(ABC):
             key (PcKey | ModifierKey): The key to tap.
             modifier_keys (list[ModifierKey] | None, optional): List of modifier keys to
                 press along with the main key. Defaults to `None`.
+            count (int, optional): The number of times to tap the key. Defaults to `1`.
         """
         raise NotImplementedError
 

--- a/src/askui/tools/askui/askui_controller.py
+++ b/src/askui/tools/askui/askui_controller.py
@@ -648,7 +648,10 @@ class AskUiControllerClient(AgentOs):
     @telemetry.record_call()
     @override
     def keyboard_tap(
-        self, key: PcKey | ModifierKey, modifier_keys: list[ModifierKey] | None = None
+        self,
+        key: PcKey | ModifierKey,
+        modifier_keys: list[ModifierKey] | None = None,
+        count: int = 1,
     ) -> None:
         """
         Press and immediately release a keyboard key.
@@ -657,18 +660,23 @@ class AskUiControllerClient(AgentOs):
             key (PcKey | ModifierKey): The key to tap.
             modifier_keys (list[ModifierKey] | None, optional): List of modifier keys to
                 press along with the main key. Defaults to `None`.
+            count (int, optional): The number of times to tap the key. Defaults to `1`.
         """
-        self._reporter.add_message("AgentOS", f'keyboard_tap("{key}", {modifier_keys})')
+        self._reporter.add_message(
+            "AgentOS",
+            f'keyboard_tap("{key}", {modifier_keys}, {count})',
+        )
         if modifier_keys is None:
             modifier_keys = []
-        self._run_recorder_action(
-            acion_class_id=controller_v1_pbs.ActionClassID_KeyboardKey_PressAndRelease,
-            action_parameters=controller_v1_pbs.ActionParameters(
-                keyboardKeyPressAndRelease=controller_v1_pbs.ActionParameters_KeyboardKey_PressAndRelease(
-                    keyName=key, modifierKeyNames=modifier_keys
-                )
-            ),
-        )
+        for _ in range(count):
+            self._run_recorder_action(
+                    acion_class_id=controller_v1_pbs.ActionClassID_KeyboardKey_PressAndRelease,
+                    action_parameters=controller_v1_pbs.ActionParameters(
+                    keyboardKeyPressAndRelease=controller_v1_pbs.ActionParameters_KeyboardKey_PressAndRelease(
+                        keyName=key, modifierKeyNames=modifier_keys
+                    )
+                ),
+            )
 
     @telemetry.record_call()
     @override


### PR DESCRIPTION
allows for simpler code when key is to be pressed repeatedly, consistent with `VisionAgent.click()`

also:
- add reporting for keyboard()