### PR TITLE
fix: override beta flag settings

### DIFF
--- a/src/askui/agent_base.py
+++ b/src/askui/agent_base.py
@@ -107,7 +107,7 @@ class AgentBase(ABC):  # noqa: B024
             "locate": model_choice.get("locate", ModelName.ASKUI),
         }
 
-    @telemetry.record_call(exclude={"goal", "on_message"})
+    @telemetry.record_call(exclude={"goal", "on_message", "settings"})
     @validate_call
     def act(
         self,

--- a/src/askui/android_agent.py
+++ b/src/askui/android_agent.py
@@ -105,6 +105,7 @@ _ANTHROPIC__CLAUDE__3_5__SONNET__20241022__ACT_SETTINGS = ActSettings(
     messages=MessageSettings(
         model=ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022.value,
         system=_SYSTEM_PROMPT,
+        betas=[],
     ),
 )
 
@@ -113,6 +114,7 @@ _CLAUDE__SONNET__4__20250514__ACT_SETTINGS = ActSettings(
         model=ModelName.CLAUDE__SONNET__4__20250514.value,
         system=_SYSTEM_PROMPT,
         thinking={"type": "enabled", "budget_tokens": 2048},
+        betas=[],
     ),
 )
 

--- a/src/askui/models/anthropic/messages_api.py
+++ b/src/askui/models/anthropic/messages_api.py
@@ -139,7 +139,9 @@ class AnthropicMessagesApi(LocateModel, GetModel, MessagesApi):
             tools=tools.to_params() if tools else NOT_GIVEN,
             max_tokens=max_tokens or self._settings.messages.max_tokens,
             model=ANTHROPIC_MODEL_MAPPING[model],
-            betas=betas or self._settings.messages.betas,
+            betas=betas
+            if not isinstance(betas, NotGiven)
+            else self._settings.messages.betas,
             system=system or self._settings.messages.system,
             thinking=thinking or self._settings.messages.thinking,
             tool_choice=tool_choice or self._settings.messages.tool_choice,

--- a/src/askui/models/askui/inference_api.py
+++ b/src/askui/models/askui/inference_api.py
@@ -230,7 +230,9 @@ class AskUiInferenceApi(GetModel, LocateModel, MessagesApi):
             "tools": tools.to_params() if tools else NOT_GIVEN,
             "max_tokens": max_tokens or self._settings.messages.max_tokens,
             "model": model,
-            "betas": betas or self._settings.messages.betas,
+            "betas": betas
+            if not isinstance(betas, NotGiven)
+            else self._settings.messages.betas,
             "system": system or self._settings.messages.system,
             "thinking": thinking or self._settings.messages.thinking,
             "tool_choice": tool_choice or self._settings.messages.tool_choice,


### PR DESCRIPTION
- fixes using `AndroidVisionAgent.act()` with Claude 4 behind AskUI API and empty betas (default)
- keep default betas on inference side as `["computer_20241022"]` to be backwards compatible
- allow overriding with empty list
- remove `settings` parameter of `AgentBase.act()` for now from telemetry as it is not fully serializable ⟶ make it serializable in later step