### PR TITLE
Switch multi-tool execution from sequential to parallel with ThreadPoolExecutor

### DIFF
--- a/src/askui/models/shared/agent.py
+++ b/src/askui/models/shared/agent.py
@@ -165,6 +165,9 @@ class Agent(ActModel):
             for content_block in message.content
             if content_block.type == "tool_use"
         ]
+        if len(tool_use_content_blocks) == 0:
+            return None
+
         content = tool_collection.run(tool_use_content_blocks)
         if len(content) == 0:
             return None

--- a/src/askui/models/shared/tools.py
+++ b/src/askui/models/shared/tools.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from anthropic.types.beta import BetaToolParam, BetaToolUnionParam
@@ -132,10 +133,10 @@ class ToolCollection:
     def run(
         self, tool_use_block_params: list[ToolUseBlockParam]
     ) -> list[ContentBlockParam]:
-        return [
-            self._run_tool(tool_use_block_param)
-            for tool_use_block_param in tool_use_block_params
-        ]
+        if len(tool_use_block_params) == 1:
+            return [self._run_tool(tool_use_block_params[0])]
+        with ThreadPoolExecutor() as executor:
+            return list(executor.map(self._run_tool, tool_use_block_params))
 
     def _run_tool(
         self, tool_use_block_param: ToolUseBlockParam


### PR DESCRIPTION
During testing, running the tools in parallel was up to 9 seconds faster than running them sequentially.
Number of tools: 10
Sequential run: 13.5814 seconds
Parallel (threaded) run: 4.2600 seconds