### PR TITLE
fix: change `ModelName` to a regular class so that (class) constants can be used like regular strings in Python >3.10

### DIFF
--- a/src/askui/agent.py
+++ b/src/askui/agent.py
@@ -48,7 +48,7 @@ _SYSTEM_PROMPT = f"""<SYSTEM_CAPABILITY>
 
 _ANTHROPIC__CLAUDE__3_5__SONNET__20241022__ACT_SETTINGS = ActSettings(
     messages=MessageSettings(
-        model=ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022.value,
+        model=ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022,
         system=_SYSTEM_PROMPT,
         betas=[COMPUTER_USE_20241022_BETA_FLAG],
     ),
@@ -56,7 +56,7 @@ _ANTHROPIC__CLAUDE__3_5__SONNET__20241022__ACT_SETTINGS = ActSettings(
 
 _CLAUDE__SONNET__4__20250514__ACT_SETTINGS = ActSettings(
     messages=MessageSettings(
-        model=ModelName.CLAUDE__SONNET__4__20250514.value,
+        model=ModelName.CLAUDE__SONNET__4__20250514,
         system=_SYSTEM_PROMPT,
         betas=[COMPUTER_USE_20250124_BETA_FLAG],
         thinking={"type": "enabled", "budget_tokens": 2048},

--- a/src/askui/android_agent.py
+++ b/src/askui/android_agent.py
@@ -103,7 +103,7 @@ Your primary goal is to execute tasks efficiently and reliably while maintaining
 
 _ANTHROPIC__CLAUDE__3_5__SONNET__20241022__ACT_SETTINGS = ActSettings(
     messages=MessageSettings(
-        model=ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022.value,
+        model=ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022,
         system=_SYSTEM_PROMPT,
         betas=[],
     ),
@@ -111,7 +111,7 @@ _ANTHROPIC__CLAUDE__3_5__SONNET__20241022__ACT_SETTINGS = ActSettings(
 
 _CLAUDE__SONNET__4__20250514__ACT_SETTINGS = ActSettings(
     messages=MessageSettings(
-        model=ModelName.CLAUDE__SONNET__4__20250514.value,
+        model=ModelName.CLAUDE__SONNET__4__20250514,
         system=_SYSTEM_PROMPT,
         thinking={"type": "enabled", "budget_tokens": 2048},
         betas=[],

--- a/src/askui/models/anthropic/messages_api.py
+++ b/src/askui/models/anthropic/messages_api.py
@@ -63,10 +63,6 @@ ANTHROPIC_MODEL_MAPPING: IdentityDefaultDict[ModelName | str, str] = (
                 "claude-3-5-sonnet-20241022"
             ),
             ModelName.CLAUDE__SONNET__4__20250514: "claude-sonnet-4-20250514",
-            ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022.value: (
-                "claude-3-5-sonnet-20241022"
-            ),
-            ModelName.CLAUDE__SONNET__4__20250514.value: "claude-sonnet-4-20250514",
         }
     )
 )

--- a/src/askui/models/models.py
+++ b/src/askui/models/models.py
@@ -1,7 +1,6 @@
 import abc
 import re
 from collections.abc import Iterator
-from enum import Enum
 from typing import Annotated, Callable, Type
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
@@ -16,10 +15,11 @@ from askui.models.types.response_schemas import ResponseSchema
 from askui.utils.image_utils import ImageSource
 
 
-class ModelName(str, Enum):
+class ModelName:
     """Enumeration of all available model names in AskUI.
 
-    This enum provides type-safe access to model identifiers used throughout the
+    This enum is not really an `enum.Enum` but rather a collection of literal strings.
+    It provides type-safe access to model identifiers used throughout the
     library. Each model name corresponds to a specific AI model or model composition
     that can be used for different tasks like acting, getting information, or locating
     elements.

--- a/src/askui/web_agent.py
+++ b/src/askui/web_agent.py
@@ -39,7 +39,7 @@ _SYSTEM_PROMPT = f"""
 
 _ANTHROPIC__CLAUDE__3_5__SONNET__20241022__ACT_SETTINGS = ActSettings(
     messages=MessageSettings(
-        model=ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022.value,
+        model=ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022,
         system=_SYSTEM_PROMPT,
         betas=[COMPUTER_USE_20241022_BETA_FLAG],
     ),
@@ -47,7 +47,7 @@ _ANTHROPIC__CLAUDE__3_5__SONNET__20241022__ACT_SETTINGS = ActSettings(
 
 _CLAUDE__SONNET__4__20250514__ACT_SETTINGS = ActSettings(
     messages=MessageSettings(
-        model=ModelName.CLAUDE__SONNET__4__20250514.value,
+        model=ModelName.CLAUDE__SONNET__4__20250514,
         system=_SYSTEM_PROMPT,
         betas=[COMPUTER_USE_20250124_BETA_FLAG],
         thinking={"type": "enabled", "budget_tokens": 2048},

--- a/src/askui/web_testing_agent.py
+++ b/src/askui/web_testing_agent.py
@@ -67,7 +67,7 @@ _TESTING_SYSTEM_PROMPT = f"""
 
 _ANTHROPIC__CLAUDE__3_5__SONNET__20241022__ACT_SETTINGS = ActSettings(
     messages=MessageSettings(
-        model=ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022.value,
+        model=ModelName.ANTHROPIC__CLAUDE__3_5__SONNET__20241022,
         system=_TESTING_SYSTEM_PROMPT,
         betas=[COMPUTER_USE_20241022_BETA_FLAG],
     ),
@@ -75,7 +75,7 @@ _ANTHROPIC__CLAUDE__3_5__SONNET__20241022__ACT_SETTINGS = ActSettings(
 
 _CLAUDE__SONNET__4__20250514__ACT_SETTINGS = ActSettings(
     messages=MessageSettings(
-        model=ModelName.CLAUDE__SONNET__4__20250514.value,
+        model=ModelName.CLAUDE__SONNET__4__20250514,
         system=_TESTING_SYSTEM_PROMPT,
         betas=[COMPUTER_USE_20250124_BETA_FLAG],
         thinking={"type": "enabled", "budget_tokens": 2048},

--- a/tests/e2e/agent/test_get.py
+++ b/tests/e2e/agent/test_get.py
@@ -207,7 +207,9 @@ def test_get_with_string_schema(
     assert response in ["https://github.com/login", "github.com/login"]
 
 
-@pytest.mark.parametrize("model", [ModelName.ASKUI])
+@pytest.mark.parametrize(
+    "model", [ModelName.ASKUI, ModelName.ASKUI__GEMINI__2_5__FLASH]
+)
 def test_get_with_boolean_schema(
     vision_agent: VisionAgent,
     github_login_screenshot: PILImage.Image,


### PR DESCRIPTION
…can be used like regular strings in Python > 3.10

- e.g., fixes issues with using Gemini where, e.g., `"ModelName.GEMINI__2_5__FLASH"` was passed as model id instead of `"gemini-2.5-flash"`