### PR TITLE
Support devices with empty display name

### DIFF
--- a/src/askui/tools/android/ppadb_agent_os.py
+++ b/src/askui/tools/android/ppadb_agent_os.py
@@ -50,7 +50,7 @@ class PpadbAgentOs(AndroidAgentOs):
         for line in output.splitlines():
             if line.startswith("Display"):
                 match = re.match(
-                    r"Display (\d+) .* displayName=\"([^\"]+)\"",
+                    r"Display (\d+) .* displayName=\"([^\"]*?)\"",
                     line,
                 )
                 if match:


### PR DESCRIPTION
We discovered that on some Android devices the display name may be empty, which causes issues with screencap.