### PR TITLE
feat(chat)!: diff. default/custom (workspace scoped) assistants and mcp configs

### DIFF
--- a/src/askui/chat/api/app.py
+++ b/src/askui/chat/api/app.py
@@ -18,6 +18,7 @@ from askui.chat.api.threads.router import router as threads_router
 from askui.utils.api_utils import (
     ConflictError,
     FileTooLargeError,
+    ForbiddenError,
     LimitReachedError,
     NotFoundError,
 )
@@ -103,6 +104,17 @@ def file_too_large_error_handler(
 ) -> JSONResponse:
     return JSONResponse(
         status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+        content={"detail": str(exc)},
+    )
+
+
+@app.exception_handler(ForbiddenError)
+def forbidden_error_handler(
+    request: Request,  # noqa: ARG001
+    exc: ForbiddenError,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status.HTTP_403_FORBIDDEN,
         content={"detail": str(exc)},
     )
 

--- a/src/askui/chat/api/assistants/models.py
+++ b/src/askui/chat/api/assistants/models.py
@@ -2,8 +2,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from askui.chat.api.models import AssistantId
-from askui.utils.api_utils import Resource
+from askui.chat.api.models import AssistantId, WorkspaceId, WorkspaceResource
 from askui.utils.datetime_utils import UnixDatetime, now
 from askui.utils.id_utils import generate_time_ordered_id
 from askui.utils.not_given import NOT_GIVEN, BaseModelWithNotGiven, NotGiven
@@ -33,7 +32,7 @@ class AssistantModifyParams(BaseModelWithNotGiven):
     system: str | NotGiven = NOT_GIVEN
 
 
-class Assistant(AssistantBase, Resource):
+class Assistant(AssistantBase, WorkspaceResource):
     """An assistant that can be used in a thread."""
 
     id: AssistantId
@@ -41,10 +40,13 @@ class Assistant(AssistantBase, Resource):
     created_at: UnixDatetime
 
     @classmethod
-    def create(cls, params: AssistantCreateParams) -> "Assistant":
+    def create(
+        cls, workspace_id: WorkspaceId, params: AssistantCreateParams
+    ) -> "Assistant":
         return cls(
             id=generate_time_ordered_id("asst"),
             created_at=now(),
+            workspace_id=workspace_id,
             **params.model_dump(),
         )
 

--- a/src/askui/chat/api/assistants/router.py
+++ b/src/askui/chat/api/assistants/router.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, status
+from typing import Annotated
+
+from fastapi import APIRouter, Header, status
 
 from askui.chat.api.assistants.dependencies import AssistantServiceDep
 from askui.chat.api.assistants.models import (
@@ -8,7 +10,7 @@ from askui.chat.api.assistants.models import (
 )
 from askui.chat.api.assistants.service import AssistantService
 from askui.chat.api.dependencies import ListQueryDep
-from askui.chat.api.models import AssistantId
+from askui.chat.api.models import AssistantId, WorkspaceId
 from askui.utils.api_utils import ListQuery, ListResponse
 
 router = APIRouter(prefix="/assistants", tags=["assistants"])
@@ -16,40 +18,49 @@ router = APIRouter(prefix="/assistants", tags=["assistants"])
 
 @router.get("")
 def list_assistants(
+    askui_workspace: Annotated[WorkspaceId | None, Header()],
     query: ListQuery = ListQueryDep,
     assistant_service: AssistantService = AssistantServiceDep,
 ) -> ListResponse[Assistant]:
-    return assistant_service.list_(query=query)
+    return assistant_service.list_(workspace_id=askui_workspace, query=query)
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)
 def create_assistant(
     params: AssistantCreateParams,
+    askui_workspace: Annotated[WorkspaceId, Header()],
     assistant_service: AssistantService = AssistantServiceDep,
 ) -> Assistant:
-    return assistant_service.create(params)
+    return assistant_service.create(workspace_id=askui_workspace, params=params)
 
 
 @router.get("/{assistant_id}")
 def retrieve_assistant(
     assistant_id: AssistantId,
+    askui_workspace: Annotated[WorkspaceId | None, Header()],
     assistant_service: AssistantService = AssistantServiceDep,
 ) -> Assistant:
-    return assistant_service.retrieve(assistant_id)
+    return assistant_service.retrieve(
+        workspace_id=askui_workspace, assistant_id=assistant_id
+    )
 
 
 @router.post("/{assistant_id}")
 def modify_assistant(
     assistant_id: AssistantId,
+    askui_workspace: Annotated[WorkspaceId | None, Header()],
     params: AssistantModifyParams,
     assistant_service: AssistantService = AssistantServiceDep,
 ) -> Assistant:
-    return assistant_service.modify(assistant_id, params)
+    return assistant_service.modify(
+        workspace_id=askui_workspace, assistant_id=assistant_id, params=params
+    )
 
 
 @router.delete("/{assistant_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_assistant(
     assistant_id: AssistantId,
+    askui_workspace: Annotated[WorkspaceId | None, Header()],
     assistant_service: AssistantService = AssistantServiceDep,
 ) -> None:
-    assistant_service.delete(assistant_id)
+    assistant_service.delete(workspace_id=askui_workspace, assistant_id=assistant_id)

--- a/src/askui/chat/api/dependencies.py
+++ b/src/askui/chat/api/dependencies.py
@@ -6,6 +6,7 @@ from fastapi import Depends, Header
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import UUID4
 
+from askui.chat.api.models import WorkspaceId
 from askui.chat.api.settings import Settings
 from askui.utils.api_utils import ListQuery
 
@@ -60,10 +61,10 @@ SetEnvFromHeadersDep = Depends(set_env_from_headers)
 
 
 def get_workspace_dir(
-    askui_workspace: Annotated[str, Header()],
+    askui_workspace: Annotated[WorkspaceId, Header()],
     settings: Settings = SettingsDep,
 ) -> Path:
-    return settings.data_dir / "workspaces" / askui_workspace
+    return settings.data_dir / "workspaces" / str(askui_workspace)
 
 
 WorkspaceDirDep = Depends(get_workspace_dir)

--- a/src/askui/chat/api/mcp_configs/dependencies.py
+++ b/src/askui/chat/api/mcp_configs/dependencies.py
@@ -1,14 +1,13 @@
-from pathlib import Path
-
 from fastapi import Depends
 
-from askui.chat.api.dependencies import WorkspaceDirDep
+from askui.chat.api.dependencies import SettingsDep
 from askui.chat.api.mcp_configs.service import McpConfigService
+from askui.chat.api.settings import Settings
 
 
-def get_mcp_config_service(workspace_dir: Path = WorkspaceDirDep) -> McpConfigService:
+def get_mcp_config_service(settings: Settings = SettingsDep) -> McpConfigService:
     """Get McpConfigService instance."""
-    return McpConfigService(workspace_dir)
+    return McpConfigService(settings.data_dir)
 
 
 McpConfigServiceDep = Depends(get_mcp_config_service)

--- a/src/askui/chat/api/mcp_configs/models.py
+++ b/src/askui/chat/api/mcp_configs/models.py
@@ -3,8 +3,7 @@ from typing import Literal
 from fastmcp.mcp_config import RemoteMCPServer, StdioMCPServer
 from pydantic import BaseModel
 
-from askui.chat.api.models import McpConfigId
-from askui.utils.api_utils import Resource
+from askui.chat.api.models import McpConfigId, WorkspaceId, WorkspaceResource
 from askui.utils.datetime_utils import UnixDatetime, now
 from askui.utils.id_utils import generate_time_ordered_id
 from askui.utils.not_given import NOT_GIVEN, BaseModelWithNotGiven, NotGiven
@@ -30,7 +29,7 @@ class McpConfigModifyParams(BaseModelWithNotGiven):
     mcp_server: McpServer | NotGiven = NOT_GIVEN
 
 
-class McpConfig(McpConfigBase, Resource):
+class McpConfig(McpConfigBase, WorkspaceResource):
     """An MCP configuration that can be stored and managed."""
 
     id: McpConfigId
@@ -38,10 +37,13 @@ class McpConfig(McpConfigBase, Resource):
     created_at: UnixDatetime
 
     @classmethod
-    def create(cls, params: McpConfigCreateParams) -> "McpConfig":
+    def create(
+        cls, workspace_id: WorkspaceId, params: McpConfigCreateParams
+    ) -> "McpConfig":
         return cls(
             id=generate_time_ordered_id("mcpcnf"),
             created_at=now(),
+            workspace_id=workspace_id,
             **params.model_dump(),
         )
 

--- a/src/askui/chat/api/mcp_configs/router.py
+++ b/src/askui/chat/api/mcp_configs/router.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, status
+from typing import Annotated
+
+from fastapi import APIRouter, Header, status
 
 from askui.chat.api.dependencies import ListQueryDep
 from askui.chat.api.mcp_configs.dependencies import McpConfigServiceDep
@@ -8,7 +10,7 @@ from askui.chat.api.mcp_configs.models import (
     McpConfigModifyParams,
 )
 from askui.chat.api.mcp_configs.service import McpConfigService
-from askui.chat.api.models import McpConfigId
+from askui.chat.api.models import McpConfigId, WorkspaceId
 from askui.utils.api_utils import ListQuery, ListResponse
 
 router = APIRouter(prefix="/mcp-configs", tags=["mcp-configs"])
@@ -16,44 +18,53 @@ router = APIRouter(prefix="/mcp-configs", tags=["mcp-configs"])
 
 @router.get("", response_model_exclude_none=True)
 def list_mcp_configs(
+    askui_workspace: Annotated[WorkspaceId | None, Header()],
     query: ListQuery = ListQueryDep,
     mcp_config_service: McpConfigService = McpConfigServiceDep,
 ) -> ListResponse[McpConfig]:
-    return mcp_config_service.list_(query=query)
+    return mcp_config_service.list_(workspace_id=askui_workspace, query=query)
 
 
 @router.post("", status_code=status.HTTP_201_CREATED, response_model_exclude_none=True)
 def create_mcp_config(
     params: McpConfigCreateParams,
+    askui_workspace: Annotated[WorkspaceId, Header()],
     mcp_config_service: McpConfigService = McpConfigServiceDep,
 ) -> McpConfig:
     """Create a new MCP configuration."""
-    return mcp_config_service.create(params)
+    return mcp_config_service.create(workspace_id=askui_workspace, params=params)
 
 
 @router.get("/{mcp_config_id}", response_model_exclude_none=True)
 def retrieve_mcp_config(
     mcp_config_id: McpConfigId,
+    askui_workspace: Annotated[WorkspaceId | None, Header()],
     mcp_config_service: McpConfigService = McpConfigServiceDep,
 ) -> McpConfig:
     """Get an MCP configuration by ID."""
-    return mcp_config_service.retrieve(mcp_config_id)
+    return mcp_config_service.retrieve(
+        workspace_id=askui_workspace, mcp_config_id=mcp_config_id
+    )
 
 
 @router.post("/{mcp_config_id}", response_model_exclude_none=True)
 def modify_mcp_config(
     mcp_config_id: McpConfigId,
     params: McpConfigModifyParams,
+    askui_workspace: Annotated[WorkspaceId | None, Header()],
     mcp_config_service: McpConfigService = McpConfigServiceDep,
 ) -> McpConfig:
     """Update an MCP configuration."""
-    return mcp_config_service.modify(mcp_config_id, params)
+    return mcp_config_service.modify(
+        workspace_id=askui_workspace, mcp_config_id=mcp_config_id, params=params
+    )
 
 
 @router.delete("/{mcp_config_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_mcp_config(
     mcp_config_id: McpConfigId,
+    askui_workspace: Annotated[WorkspaceId | None, Header()],
     mcp_config_service: McpConfigService = McpConfigServiceDep,
 ) -> None:
     """Delete an MCP configuration."""
-    mcp_config_service.delete(mcp_config_id)
+    mcp_config_service.delete(workspace_id=askui_workspace, mcp_config_id=mcp_config_id)

--- a/src/askui/chat/api/models.py
+++ b/src/askui/chat/api/models.py
@@ -1,5 +1,8 @@
-from typing import Annotated
+from typing import Annotated, TypeVar
 
+from pydantic import UUID4
+
+from askui.utils.api_utils import Resource
 from askui.utils.id_utils import IdField
 
 AssistantId = Annotated[str, IdField("asst")]
@@ -8,3 +11,11 @@ FileId = Annotated[str, IdField("file")]
 MessageId = Annotated[str, IdField("msg")]
 RunId = Annotated[str, IdField("run")]
 ThreadId = Annotated[str, IdField("thread")]
+WorkspaceId = UUID4
+
+
+class WorkspaceResource(Resource):
+    workspace_id: WorkspaceId | None = None
+
+
+WorkspaceResourceT = TypeVar("WorkspaceResourceT", bound=WorkspaceResource)

--- a/src/askui/chat/api/runs/dependencies.py
+++ b/src/askui/chat/api/runs/dependencies.py
@@ -5,6 +5,8 @@ from fastapi import Depends
 from askui.chat.api.assistants.dependencies import AssistantServiceDep
 from askui.chat.api.assistants.service import AssistantService
 from askui.chat.api.dependencies import WorkspaceDirDep
+from askui.chat.api.mcp_configs.dependencies import McpConfigServiceDep
+from askui.chat.api.mcp_configs.service import McpConfigService
 from askui.chat.api.messages.dependencies import MessageServiceDep, MessageTranslatorDep
 from askui.chat.api.messages.service import MessageService
 from askui.chat.api.messages.translator import MessageTranslator
@@ -15,12 +17,17 @@ from .service import RunService
 def get_runs_service(
     workspace_dir: Path = WorkspaceDirDep,
     assistant_service: AssistantService = AssistantServiceDep,
+    mcp_config_service: McpConfigService = McpConfigServiceDep,
     message_service: MessageService = MessageServiceDep,
     message_translator: MessageTranslator = MessageTranslatorDep,
 ) -> RunService:
     """Get RunService instance."""
     return RunService(
-        workspace_dir, assistant_service, message_service, message_translator
+        base_dir=workspace_dir,
+        assistant_service=assistant_service,
+        mcp_config_service=mcp_config_service,
+        message_service=message_service,
+        message_translator=message_translator,
     )
 
 

--- a/src/askui/chat/api/runs/service.py
+++ b/src/askui/chat/api/runs/service.py
@@ -3,17 +3,21 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import anyio
+from typing_extensions import override
 
 from askui.chat.api.assistants.service import AssistantService
+from askui.chat.api.mcp_configs.service import McpConfigService
 from askui.chat.api.messages.service import MessageService
 from askui.chat.api.messages.translator import MessageTranslator
-from askui.chat.api.models import RunId, ThreadId
+from askui.chat.api.models import RunId, ThreadId, WorkspaceId
 from askui.chat.api.runs.models import Run, RunCreateParams
-from askui.chat.api.runs.runner.events import Events
-from askui.chat.api.runs.runner.events.done_events import DoneEvent
-from askui.chat.api.runs.runner.events.error_events import ErrorEvent
-from askui.chat.api.runs.runner.events.run_events import RunEvent
-from askui.chat.api.runs.runner.runner import Runner
+from askui.chat.api.runs.runner.events.events import (
+    DoneEvent,
+    ErrorEvent,
+    Events,
+    RunEvent,
+)
+from askui.chat.api.runs.runner.runner import Runner, RunnerRunService
 from askui.utils.api_utils import (
     ConflictError,
     ListQuery,
@@ -23,18 +27,20 @@ from askui.utils.api_utils import (
 )
 
 
-class RunService:
+class RunService(RunnerRunService):
     """Service for managing Run resources with filesystem persistence."""
 
     def __init__(
         self,
         base_dir: Path,
         assistant_service: AssistantService,
+        mcp_config_service: McpConfigService,
         message_service: MessageService,
         message_translator: MessageTranslator,
     ) -> None:
         self._base_dir = base_dir
         self._assistant_service = assistant_service
+        self._mcp_config_service = mcp_config_service
         self._message_service = message_service
         self._message_translator = message_translator
 
@@ -56,21 +62,28 @@ class RunService:
 
     def _create(self, thread_id: ThreadId, params: RunCreateParams) -> Run:
         run = Run.create(thread_id, params)
-        self._save(run, new=True)
+        self.save(run, new=True)
         return run
 
     async def create(
-        self, thread_id: ThreadId, params: RunCreateParams
+        self,
+        workspace_id: WorkspaceId,
+        thread_id: ThreadId,
+        params: RunCreateParams,
     ) -> tuple[Run, AsyncGenerator[Events, None]]:
-        assistant = self._assistant_service.retrieve(params.assistant_id)
+        assistant = self._assistant_service.retrieve(
+            workspace_id=workspace_id, assistant_id=params.assistant_id
+        )
         run = self._create(thread_id, params)
         send_stream, receive_stream = anyio.create_memory_object_stream[Events]()
         runner = Runner(
-            assistant,
-            run,
-            self._base_dir,
-            self._message_service,
-            self._message_translator,
+            workspace_id=workspace_id,
+            assistant=assistant,
+            run=run,
+            message_service=self._message_service,
+            message_translator=self._message_translator,
+            mcp_config_service=self._mcp_config_service,
+            run_service=self,
         )
 
         async def event_generator() -> AsyncGenerator[Events, None]:
@@ -108,6 +121,7 @@ class RunService:
 
         return run, event_generator()
 
+    @override
     def retrieve(self, thread_id: ThreadId, run_id: RunId) -> Run:
         try:
             run_file = self._get_run_path(thread_id, run_id)
@@ -125,10 +139,11 @@ class RunService:
         if run.status in ("cancelled", "cancelling", "completed", "failed", "expired"):
             return run
         run.tried_cancelling_at = datetime.now(tz=timezone.utc)
-        self._save(run)
+        self.save(run)
         return run
 
-    def _save(self, run: Run, new: bool = False) -> None:
+    @override
+    def save(self, run: Run, new: bool = False) -> None:
         runs_dir = self.get_runs_dir(run.thread_id)
         runs_dir.mkdir(parents=True, exist_ok=True)
         run_file = self._get_run_path(run.thread_id, run.id, new=new)

--- a/src/askui/chat/api/threads/facade.py
+++ b/src/askui/chat/api/threads/facade.py
@@ -2,7 +2,7 @@ from collections.abc import AsyncGenerator
 
 from askui.chat.api.messages.models import Message, MessageCreateParams
 from askui.chat.api.messages.service import MessageService
-from askui.chat.api.models import ThreadId
+from askui.chat.api.models import ThreadId, WorkspaceId
 from askui.chat.api.runs.models import Run, RunCreateParams, ThreadAndRunCreateParams
 from askui.chat.api.runs.runner.events.events import Events
 from askui.chat.api.runs.service import RunService
@@ -37,18 +37,26 @@ class ThreadFacade:
         return self._message_service.create(thread_id, params)
 
     async def create_run(
-        self, thread_id: ThreadId, params: RunCreateParams
+        self, workspace_id: WorkspaceId, thread_id: ThreadId, params: RunCreateParams
     ) -> tuple[Run, AsyncGenerator[Events, None]]:
         """Create a run, ensuring the thread exists first."""
         self._ensure_thread_exists(thread_id)
-        return await self._run_service.create(thread_id, params)
+        return await self._run_service.create(
+            workspace_id=workspace_id,
+            thread_id=thread_id,
+            params=params,
+        )
 
     async def create_thread_and_run(
-        self, params: ThreadAndRunCreateParams
+        self, workspace_id: WorkspaceId, params: ThreadAndRunCreateParams
     ) -> tuple[Run, AsyncGenerator[Events, None]]:
         """Create a thread and a run, ensuring the thread exists first."""
         thread = self._thread_service.create(params.thread)
-        return await self._run_service.create(thread.id, params)
+        return await self._run_service.create(
+            workspace_id=workspace_id,
+            thread_id=thread.id,
+            params=params,
+        )
 
     def list_messages(
         self, thread_id: ThreadId, query: ListQuery

--- a/src/askui/chat/api/utils.py
+++ b/src/askui/chat/api/utils.py
@@ -1,0 +1,13 @@
+from typing import Callable, Type
+
+from askui.chat.api.models import WorkspaceId, WorkspaceResourceT
+
+
+def build_workspace_filter_fn(
+    workspace: WorkspaceId | None,
+    resource_type: Type[WorkspaceResourceT],  # noqa: ARG001
+) -> Callable[[WorkspaceResourceT], bool]:
+    def filter_fn(resource: WorkspaceResourceT) -> bool:
+        return resource.workspace_id is None or resource.workspace_id == workspace
+
+    return filter_fn

--- a/src/askui/utils/api_utils.py
+++ b/src/askui/utils/api_utils.py
@@ -48,6 +48,10 @@ class NotFoundError(ApiError):
     pass
 
 
+class ForbiddenError(ApiError):
+    pass
+
+
 class FileTooLargeError(ApiError):
     def __init__(self, max_size: int):
         self.max_size = max_size

--- a/tests/integration/chat/api/test_runs.py
+++ b/tests/integration/chat/api/test_runs.py
@@ -14,6 +14,14 @@ from askui.chat.api.threads.models import Thread
 from askui.chat.api.threads.service import ThreadService
 
 
+def create_mock_mcp_config_service() -> Mock:
+    """Create a properly configured mock MCP config service."""
+    mock_service = Mock()
+    # Configure mock to return proper data structure
+    mock_service.list_.return_value.data = []
+    return mock_service
+
+
 class TestRunsAPI:
     """Test suite for the runs API endpoints."""
 
@@ -46,13 +54,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -116,13 +126,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -187,13 +199,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -241,13 +255,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -305,13 +321,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -363,13 +381,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -410,13 +430,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -469,13 +491,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -519,13 +543,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -572,13 +598,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -638,13 +666,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -686,13 +716,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -771,13 +803,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -855,13 +889,15 @@ class TestRunsAPI:
 
         def override_runs_service() -> RunService:
             mock_assistant_service = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             mock_message_service = Mock()
             mock_message_translator = Mock()
             return RunService(
-                workspace_path,
-                mock_assistant_service,
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=mock_assistant_service,
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         app.dependency_overrides[get_thread_service] = override_thread_service
@@ -944,13 +980,15 @@ class TestRunsAPI:
         def override_runs_service() -> RunService:
             mock_message_service = Mock()
             mock_message_translator = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             from askui.chat.api.assistants.service import AssistantService
 
             return RunService(
-                workspace_path,
-                AssistantService(workspace_path),
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=AssistantService(workspace_path),
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         def override_assistant_service() -> AssistantService:
@@ -1009,7 +1047,7 @@ class TestRunsAPI:
             created_at=1234567890,
             name="Empty Tools Assistant",
             tools=[],
-            system="You are an assistant with no tools.",
+            system="You are a assistant with no tools.",
         )
         (assistants_dir / "asst_customempty123.json").write_text(
             mock_assistant.model_dump_json()
@@ -1030,13 +1068,15 @@ class TestRunsAPI:
         def override_runs_service() -> RunService:
             mock_message_service = Mock()
             mock_message_translator = Mock()
+            mock_mcp_config_service = create_mock_mcp_config_service()
             from askui.chat.api.assistants.service import AssistantService
 
             return RunService(
-                workspace_path,
-                AssistantService(workspace_path),
-                mock_message_service,
-                mock_message_translator,
+                base_dir=workspace_path,
+                assistant_service=AssistantService(workspace_path),
+                mcp_config_service=mock_mcp_config_service,
+                message_service=mock_message_service,
+                message_translator=mock_message_translator,
             )
 
         def override_assistant_service() -> AssistantService:


### PR DESCRIPTION
**BREAKING CHANGE**:
- existing mcp_configs won't be accessible anymore through api but only through the file system
- workspace id expected to be a uuid4 --> resources saved with non-uuid4 askui-workspace header won't be accessible anymore through API but only through the file system (AskUI Hub already uses this format so if you never used the API directly, there is nothing to do)
- existing custom agents can only be modified/deleted through file system but not API