### PR TITLE
fix: typing after start of controller by starting without overlay by default

### DIFF
--- a/src/askui/chat/api/runs/runner/runner.py
+++ b/src/askui/chat/api/runs/runner/runner.py
@@ -100,7 +100,13 @@ class Runner:
             "workspace_id": str(self._workspace_id),
             "assistant_id": str(self._run.assistant_id),
         }
+        is_custom_assistant = self._assistant.workspace_id is not None
+        custom_assistant_str = "custom " if is_custom_assistant else ""
         return [
+            BetaTextBlockParam(
+                type="text",
+                text=f'You are an {custom_assistant_str}AI agent called "{self._assistant.name}" that is part of Caesr AI (AI agent platform developed by the company AskUI).',
+            ),
             *(
                 [
                     BetaTextBlockParam(

--- a/src/askui/tools/askui/askui_controller_settings.py
+++ b/src/askui/tools/askui/askui_controller_settings.py
@@ -49,7 +49,7 @@ class AskUiControllerSettings(BaseSettings):
         ".",
     )
     controller_args: str | None = Field(
-        default="--showOverlay true",
+        default="--showOverlay false",
         description=(
             "Arguments to pass to the AskUI Remote Device Controller executable. "
             "Supported arguments: --showOverlay [true|false], --debugDraw [true|false],"
@@ -57,7 +57,7 @@ class AskUiControllerSettings(BaseSettings):
             "Examples:\n"
             "  --showOverlay false --configFile /path/to/config.json\n"
             "  --showOverlay false\n"
-            "Default: --showOverlay true"
+            "Default: --showOverlay false"
         ),
     )
 

--- a/tests/unit/tools/askui/test_askui_controller_settings.py
+++ b/tests/unit/tools/askui/test_askui_controller_settings.py
@@ -400,7 +400,7 @@ class TestAskUiControllerSettings:
     def test_controller_args_default_value(self) -> None:
         """Test that controller_args is set correctly with default value."""
         settings = AskUiControllerSettings(component_registry_file="/dummy")
-        assert settings.controller_args == "--showOverlay true"
+        assert settings.controller_args == "--showOverlay false"
 
     def test_controller_args_constructor(self) -> None:
         """Test that controller_args is set correctly with constructor."""


### PR DESCRIPTION
- if using overlay, the focus needs to be set to window where
  you want to type as overlay gets focus after start of controller
  --> this is not expected behavior for end users and as they have enough
  observability using chat, we disable it by default
