### PR TITLE
chore(models): remove 413 from retryable status codes

### DIFF
--- a/src/askui/models/askui/retry_utils.py
+++ b/src/askui/models/askui/retry_utils.py
@@ -45,4 +45,4 @@ class wait_for_retry_after_header(wait_base):
         return self._fallback(retry_state)
 
 
-RETRYABLE_HTTP_STATUS_CODES = (408, 413, 429, 500, 502, 503, 504, 521, 522, 524, 529)
+RETRYABLE_HTTP_STATUS_CODES = (408, 429, 500, 502, 503, 504, 521, 522, 524, 529)


### PR DESCRIPTION
- usually if the request is too large, it is also going to be
  too large for the next request
