### PR TITLE
feat(chat): add default model setting for chat interactions

### DIFF
--- a/src/askui/chat/api/runs/dependencies.py
+++ b/src/askui/chat/api/runs/dependencies.py
@@ -4,12 +4,13 @@ from fastapi import Depends
 
 from askui.chat.api.assistants.dependencies import AssistantServiceDep
 from askui.chat.api.assistants.service import AssistantService
-from askui.chat.api.dependencies import WorkspaceDirDep
+from askui.chat.api.dependencies import SettingsDep, WorkspaceDirDep
 from askui.chat.api.mcp_clients.dependencies import McpClientManagerManagerDep
 from askui.chat.api.mcp_clients.manager import McpClientManagerManager
 from askui.chat.api.messages.chat_history_manager import ChatHistoryManager
 from askui.chat.api.messages.dependencies import ChatHistoryManagerDep
 from askui.chat.api.runs.models import RunListQuery
+from askui.chat.api.settings import Settings
 
 from .service import RunService
 
@@ -21,12 +22,14 @@ def get_runs_service(
     assistant_service: AssistantService = AssistantServiceDep,
     chat_history_manager: ChatHistoryManager = ChatHistoryManagerDep,
     mcp_client_manager_manager: McpClientManagerManager = McpClientManagerManagerDep,
+    settings: Settings = SettingsDep,
 ) -> RunService:
     return RunService(
         base_dir=workspace_dir,
         assistant_service=assistant_service,
         mcp_client_manager_manager=mcp_client_manager_manager,
         chat_history_manager=chat_history_manager,
+        settings=settings,
     )
 
 

--- a/src/askui/chat/api/runs/runner/runner.py
+++ b/src/askui/chat/api/runs/runner/runner.py
@@ -22,6 +22,7 @@ from askui.chat.api.runs.events.message_events import MessageEvent
 from askui.chat.api.runs.events.run_events import RunEvent
 from askui.chat.api.runs.events.service import RetrieveRunService
 from askui.chat.api.runs.models import Run, RunError
+from askui.chat.api.settings import Settings
 from askui.custom_agent import CustomAgent
 from askui.models.models import ModelName
 from askui.models.shared.agent_message_param import MessageParam
@@ -48,6 +49,7 @@ class Runner:
         chat_history_manager: ChatHistoryManager,
         mcp_client_manager_manager: McpClientManagerManager,
         run_service: RunnerRunService,
+        settings: Settings,
     ) -> None:
         self._workspace_id = workspace_id
         self._assistant = assistant
@@ -55,6 +57,7 @@ class Runner:
         self._chat_history_manager = chat_history_manager
         self._mcp_client_manager_manager = mcp_client_manager_manager
         self._run_service = run_service
+        self._settings = settings
 
     def _retrieve(self) -> Run:
         return self._run_service.retrieve(
@@ -137,7 +140,7 @@ class Runner:
             )
             betas = tools.retrieve_tool_beta_flags()
             system = self._build_system()
-            model = str(ModelName.CLAUDE__SONNET__4__20250514)
+            model = self._settings.model
             messages = syncify(self._chat_history_manager.retrieve_message_params)(
                 thread_id=self._run.thread_id,
                 tools=tools.to_params(),

--- a/src/askui/chat/api/runs/service.py
+++ b/src/askui/chat/api/runs/service.py
@@ -14,6 +14,7 @@ from askui.chat.api.runs.events.events import DoneEvent, ErrorEvent, Event, RunE
 from askui.chat.api.runs.events.service import EventService
 from askui.chat.api.runs.models import Run, RunCreateParams, RunListQuery
 from askui.chat.api.runs.runner.runner import Runner, RunnerRunService
+from askui.chat.api.settings import Settings
 from askui.utils.api_utils import (
     ConflictError,
     ListResponse,
@@ -40,11 +41,13 @@ class RunService(RunnerRunService):
         assistant_service: AssistantService,
         mcp_client_manager_manager: McpClientManagerManager,
         chat_history_manager: ChatHistoryManager,
+        settings: Settings,
     ) -> None:
         self._base_dir = base_dir
         self._assistant_service = assistant_service
         self._mcp_client_manager_manager = mcp_client_manager_manager
         self._chat_history_manager = chat_history_manager
+        self._settings = settings
         self._event_service = EventService(base_dir, self)
 
     def get_runs_dir(self, thread_id: ThreadId) -> Path:
@@ -86,6 +89,7 @@ class RunService(RunnerRunService):
             chat_history_manager=self._chat_history_manager,
             mcp_client_manager_manager=self._mcp_client_manager_manager,
             run_service=self,
+            settings=self._settings,
         )
 
         async def event_generator() -> AsyncGenerator[Event, None]:

--- a/src/askui/chat/api/settings.py
+++ b/src/askui/chat/api/settings.py
@@ -66,6 +66,10 @@ class Settings(BaseSettings):
             "connect to MCP servers shared across all workspaces."
         ),
     )
+    model: str = Field(
+        default="claude-sonnet-4-20250514",
+        description="Default model to use for chat interactions",
+    )
     telemetry: TelemetrySettings = Field(
         default_factory=lambda: TelemetrySettings(
             log=LogSettings(


### PR DESCRIPTION
- Introduced a new `model` field in `Settings` with a default value of `"claude-sonnet-4-20250514"` for chat interactions. You can now use, e.g., `"claude-sonnet-4-5-20250929"` by setting env variable `ASKUI__CHAT_API__MODEL` to that value