### PR TITLE
fix: remove incorrect coordinate scaling from mouse scroll deltas (SO…

### DIFF
--- a/src/askui/computer_agent.py
+++ b/src/askui/computer_agent.py
@@ -221,15 +221,15 @@ class ComputerAgent(Agent):
     @validate_call
     def mouse_scroll(
         self,
-        x: int,
-        y: int,
+        dx: int,
+        dy: int,
     ) -> None:
         """
         Simulates scrolling the mouse wheel by the specified horizontal and vertical amounts.
 
         Args:
-            x (int): The horizontal scroll amount. Positive values typically scroll right, negative values scroll left.
-            y (int): The vertical scroll amount. Positive values typically scroll down, negative values scroll up.
+            dx (int): The horizontal scroll amount. Positive values typically scroll right, negative values scroll left.
+            dy (int): The vertical scroll amount. Positive values typically scroll down, negative values scroll up.
 
         Note:
             The actual scroll direction depends on the operating system's configuration.
@@ -248,8 +248,8 @@ class ComputerAgent(Agent):
                 agent.mouse_scroll(3, 0)   # Usually scrolls right 3 units
             ```
         """
-        self._reporter.add_message("User", f'mouse_scroll: "{x}", "{y}"')
-        self.tools.os.mouse_scroll(x, y)
+        self._reporter.add_message("User", f'mouse_scroll: "{dx}", "{dy}"')
+        self.tools.os.mouse_scroll(dx, dy)
 
     @telemetry.record_call(exclude={"text", "locator"})
     @validate_call(config=ConfigDict(arbitrary_types_allowed=True))

--- a/src/askui/tools/agent_os.py
+++ b/src/askui/tools/agent_os.py
@@ -319,14 +319,14 @@ class AgentOs(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def mouse_scroll(self, x: int, y: int) -> None:
+    def mouse_scroll(self, dx: int, dy: int) -> None:
         """
         Simulates scrolling the mouse wheel.
 
         Args:
-            x (int): The horizontal scroll amount. Positive values scroll right,
+            dx (int): The horizontal scroll amount. Positive values scroll right,
                 negative values scroll left.
-            y (int): The vertical scroll amount. Positive values scroll down,
+            dy (int): The vertical scroll amount. Positive values scroll down,
                 negative values scroll up.
         """
         raise NotImplementedError

--- a/src/askui/tools/askui/askui_controller.py
+++ b/src/askui/tools/askui/askui_controller.py
@@ -503,37 +503,37 @@ class AskUiControllerClient(AgentOs):
 
     @telemetry.record_call()
     @override
-    def mouse_scroll(self, x: int, y: int) -> None:
+    def mouse_scroll(self, dx: int, dy: int) -> None:
         """
         Scroll the mouse wheel.
 
         Args:
-            x (int): The horizontal scroll amount. Positive values scroll right,
+            dx (int): The horizontal scroll amount. Positive values scroll right,
                 negative values scroll left.
-            y (int): The vertical scroll amount. Positive values scroll down,
+            dy (int): The vertical scroll amount. Positive values scroll down,
                 negative values scroll up.
         """
-        self._reporter.add_message("AgentOS", f"mouse_scroll({x}, {y})")
-        if x != 0:
+        self._reporter.add_message("AgentOS", f"mouse_scroll({dx}, {dy})")
+        if dx != 0:
             self._run_recorder_action(
                 acion_class_id=controller_v1_pbs.ActionClassID_MouseWheelScroll,
                 action_parameters=controller_v1_pbs.ActionParameters(
                     mouseWheelScroll=controller_v1_pbs.ActionParameters_MouseWheelScroll(
                         direction=controller_v1_pbs.MouseWheelScrollDirection.MouseWheelScrollDirection_Horizontal,
                         deltaType=controller_v1_pbs.MouseWheelDeltaType.MouseWheelDelta_Raw,
-                        delta=x,
+                        delta=dx,
                         milliseconds=50,
                     )
                 ),
             )
-        if y != 0:
+        if dy != 0:
             self._run_recorder_action(
                 acion_class_id=controller_v1_pbs.ActionClassID_MouseWheelScroll,
                 action_parameters=controller_v1_pbs.ActionParameters(
                     mouseWheelScroll=controller_v1_pbs.ActionParameters_MouseWheelScroll(
                         direction=controller_v1_pbs.MouseWheelScrollDirection.MouseWheelScrollDirection_Vertical,
                         deltaType=controller_v1_pbs.MouseWheelDeltaType.MouseWheelDelta_Raw,
-                        delta=y,
+                        delta=dy,
                         milliseconds=50,
                     )
                 ),

--- a/src/askui/tools/computer/mouse_scroll_tool.py
+++ b/src/askui/tools/computer/mouse_scroll_tool.py
@@ -10,9 +10,9 @@ class ComputerMouseScrollTool(ComputerBaseTool):
             name="mouse_scroll",
             description=(
                 "Scroll the mouse wheel at the current position. "
-                "The scroll amount is specified in lines. "
-                "For example, dy=3 scrolls down 3 lines and dy=-3 scrolls up 3 lines. "
-                "Use small values (1-5) for precise scrolling and larger values (10-20) for fast scrolling. "
+                "The scroll amount depends on the operating system. "
+                "On Windows, a value of 150 scrolls approximately one page. "
+                "Start with dy=150 or dy=-150 for a normal scroll and adjust based on the result. "
                 "Note: The actual scroll direction may vary depending on the OS configuration "
                 "(e.g., natural scrolling on macOS reverses the direction). "
                 "If you observe that scrolling moves in the opposite direction than expected, "
@@ -24,7 +24,7 @@ class ComputerMouseScrollTool(ComputerBaseTool):
                     "dx": {
                         "type": "integer",
                         "description": (
-                            "The horizontal scroll amount in lines. "
+                            "The horizontal scroll amount. "
                             "Positive values scroll right, negative values scroll left. "
                             "Use 0 if no horizontal scrolling is needed."
                         ),
@@ -32,7 +32,7 @@ class ComputerMouseScrollTool(ComputerBaseTool):
                     "dy": {
                         "type": "integer",
                         "description": (
-                            "The vertical scroll amount in lines. "
+                            "The vertical scroll amount. "
                             "Positive values scroll down, negative values scroll up. "
                             "Use 0 if no vertical scrolling is needed."
                         ),

--- a/src/askui/tools/computer/mouse_scroll_tool.py
+++ b/src/askui/tools/computer/mouse_scroll_tool.py
@@ -9,14 +9,20 @@ class ComputerMouseScrollTool(ComputerBaseTool):
         super().__init__(
             name="mouse_scroll",
             description=(
-                "Scroll the mouse wheel at the current position. "
-                "The scroll amount depends on the operating system. "
-                "On Windows, a value of 150 scrolls approximately one page. "
-                "Start with dy=150 or dy=-150 for a normal scroll and adjust based on the result. "
-                "Note: The actual scroll direction may vary depending on the OS configuration "
-                "(e.g., natural scrolling on macOS reverses the direction). "
-                "If you observe that scrolling moves in the opposite direction than expected, "
-                "invert the values (e.g., use negative instead of positive and vice versa)."
+                "Scroll the mouse wheel at the current "
+                "position. The scroll amount depends on "
+                "the operating system. On Windows, a value "
+                "of 150 scrolls approximately one page. "
+                "Start with dy=150 or dy=-150 for a normal "
+                "scroll and adjust based on the result. "
+                "Note: The actual scroll direction may vary "
+                "depending on the OS configuration (e.g., "
+                "natural scrolling on macOS reverses the "
+                "direction). If you observe that scrolling "
+                "moves in the opposite direction than "
+                "expected, invert the values (e.g., use "
+                "negative instead of positive and "
+                "vice versa)."
             ),
             input_schema={
                 "type": "object",
@@ -25,8 +31,10 @@ class ComputerMouseScrollTool(ComputerBaseTool):
                         "type": "integer",
                         "description": (
                             "The horizontal scroll amount. "
-                            "Positive values scroll right, negative values scroll left. "
-                            "Use 0 if no horizontal scrolling is needed."
+                            "Positive values scroll right, "
+                            "negative values scroll left. "
+                            "Use 0 if no horizontal "
+                            "scrolling is needed."
                         ),
                     },
                     "dy": {

--- a/src/askui/tools/computer/mouse_scroll_tool.py
+++ b/src/askui/tools/computer/mouse_scroll_tool.py
@@ -8,22 +8,33 @@ class ComputerMouseScrollTool(ComputerBaseTool):
     def __init__(self, agent_os: ComputerAgentOsFacade | None = None) -> None:
         super().__init__(
             name="mouse_scroll",
-            description="Scroll the mouse wheel at the current position.",
+            description=(
+                "Scroll the mouse wheel at the current position. "
+                "The scroll amount is specified in lines. "
+                "For example, dy=3 scrolls down 3 lines and dy=-3 scrolls up 3 lines. "
+                "Use small values (1-5) for precise scrolling and larger values (10-20) for fast scrolling. "
+                "Note: The actual scroll direction may vary depending on the OS configuration "
+                "(e.g., natural scrolling on macOS reverses the direction). "
+                "If you observe that scrolling moves in the opposite direction than expected, "
+                "invert the values (e.g., use negative instead of positive and vice versa)."
+            ),
             input_schema={
                 "type": "object",
                 "properties": {
                     "dx": {
                         "type": "integer",
                         "description": (
-                            "The horizontal scroll amount. "
-                            "Positive values scroll right, negative values scroll left."
+                            "The horizontal scroll amount in lines. "
+                            "Positive values scroll right, negative values scroll left. "
+                            "Use 0 if no horizontal scrolling is needed."
                         ),
                     },
                     "dy": {
                         "type": "integer",
                         "description": (
-                            "The vertical scroll amount. "
-                            "Positive values scroll down, negative values scroll up."
+                            "The vertical scroll amount in lines. "
+                            "Positive values scroll down, negative values scroll up. "
+                            "Use 0 if no vertical scrolling is needed."
                         ),
                     },
                 },

--- a/src/askui/tools/computer/mouse_scroll_tool.py
+++ b/src/askui/tools/computer/mouse_scroll_tool.py
@@ -11,18 +11,13 @@ class ComputerMouseScrollTool(ComputerBaseTool):
             description=(
                 "Scroll the mouse wheel at the current "
                 "position. The scroll amount depends on "
-                "the operating system. On Windows, a value "
-                "of 150 scrolls approximately one page. "
-                "Start with dy=150 or dy=-150 for a normal "
-                "scroll and adjust based on the result. "
-                "Note: The actual scroll direction may vary "
-                "depending on the OS configuration (e.g., "
-                "natural scrolling on macOS reverses the "
-                "direction). If you observe that scrolling "
-                "moves in the opposite direction than "
-                "expected, invert the values (e.g., use "
-                "negative instead of positive and "
-                "vice versa)."
+                "the operating system. 150 is a small "
+                "but reasonable scroll step. On Windows, "
+                "positive dy scrolls down. On macOS "
+                "(default settings), negative dy scrolls "
+                "down. If scrolling moves in the opposite "
+                "direction than expected, invert the "
+                "values."
             ),
             input_schema={
                 "type": "object",

--- a/src/askui/tools/computer/mouse_scroll_tool.py
+++ b/src/askui/tools/computer/mouse_scroll_tool.py
@@ -11,13 +11,14 @@ class ComputerMouseScrollTool(ComputerBaseTool):
             description=(
                 "Scroll the mouse wheel at the current "
                 "position. The scroll amount depends on "
-                "the operating system. 150 is a small "
-                "but reasonable scroll step. On Windows, "
-                "positive dy scrolls down. On macOS "
-                "(default settings), negative dy scrolls "
-                "down. If scrolling moves in the opposite "
-                "direction than expected, invert the "
-                "values."
+                "the operating system. Start with "
+                "dy=150 or dy=-150 for a normal scroll "
+                "and adjust based on the result. "
+                "On Windows, positive dy scrolls down. "
+                "On macOS (default settings), negative "
+                "dy scrolls down. If scrolling moves in "
+                "the opposite direction than expected, "
+                "invert the values."
             ),
             input_schema={
                 "type": "object",

--- a/src/askui/tools/computer_agent_os_facade.py
+++ b/src/askui/tools/computer_agent_os_facade.py
@@ -84,11 +84,8 @@ class ComputerAgentOsFacade(AgentOs):
     def mouse_up(self, button: MouseButton = "left") -> None:
         self._agent_os.mouse_up(button)
 
-    def mouse_scroll(self, x: int, y: int) -> None:
-        scaled_x, scaled_y = self._scale_coordinates_back(
-            x, y, check_coordinates_in_bounds=False
-        )
-        self._agent_os.mouse_scroll(scaled_x, scaled_y)
+    def mouse_scroll(self, dx: int, dy: int) -> None:
+        self._agent_os.mouse_scroll(dx, dy)
 
     def keyboard_pressed(
         self, key: PcKey | ModifierKey, modifier_keys: list[ModifierKey] | None = None

--- a/src/askui/tools/playwright/agent_os.py
+++ b/src/askui/tools/playwright/agent_os.py
@@ -259,21 +259,21 @@ class PlaywrightAgentOs(AgentOs):
         self._page.mouse.up(button=button)
 
     @override
-    def mouse_scroll(self, x: int, y: int) -> None:
+    def mouse_scroll(self, dx: int, dy: int) -> None:
         """
         Simulates scrolling the mouse wheel.
 
         Args:
-            x (int): The horizontal scroll amount. Positive values scroll right,
+            dx (int): The horizontal scroll amount. Positive values scroll right,
                 negative values scroll left.
-            y (int): The vertical scroll amount. Positive values scroll down,
+            dy (int): The vertical scroll amount. Positive values scroll down,
                 negative values scroll up.
         """
         if not self._page:
             error_msg = "No active page. Call connect() first."
             raise RuntimeError(error_msg)
 
-        self._page.mouse.wheel(delta_x=x, delta_y=y)
+        self._page.mouse.wheel(delta_x=dx, delta_y=dy)
 
     @override
     def keyboard_pressed(


### PR DESCRIPTION
…LENG-332)

Scroll delta values (dx, dy) were being scaled through `_scale_coordinates_back` in `ComputerAgentOsFacade`, treating them as absolute screen coordinates instead of relative amounts. This caused wildly incorrect scroll values sent to AgentOS (e.g., dy=-5 became dy=-189). Also renamed params from x/y to dx/dy across the scroll API for clarity and improved the tool prompt with scroll unit guidance.