### PR TITLE
fix: incorrect typing speed unit of computer type tool

### DIFF
--- a/src/askui/tools/agent_os.py
+++ b/src/askui/tools/agent_os.py
@@ -296,7 +296,7 @@ class AgentOs(ABC):
         Args:
             text (str): The text to be typed.
             typing_speed (int, optional): The speed of typing in characters per
-                minute. Defaults to `50`.
+                second. Defaults to `50`.
         """
         raise NotImplementedError
 

--- a/src/askui/tools/computer/type_tool.py
+++ b/src/askui/tools/computer/type_tool.py
@@ -19,7 +19,7 @@ class ComputerTypeTool(ComputerBaseTool):
                     "typing_speed": {
                         "type": "integer",
                         "description": (
-                            "The speed of typing in characters per minute."
+                            "The speed of typing in characters per second."
                             " Defaults to 50"
                         ),
                         "default": 50,
@@ -35,5 +35,5 @@ class ComputerTypeTool(ComputerBaseTool):
         self.agent_os.type(text, typing_speed)
         return (
             f"Text was typed: {text} with typing speed: "
-            f" {typing_speed} characters per minute."
+            f" {typing_speed} characters per second."
         )


### PR DESCRIPTION
the description stated that typing speed was character per minute, in fact, the parameter controls the typing speed in characters per second.