### PR TITLE
fix: add auto-conversion of process_id paramto int

### DIFF
--- a/src/askui/tools/store/computer/experimental/window_management/list_process_windows.py
+++ b/src/askui/tools/store/computer/experimental/window_management/list_process_windows.py
@@ -46,6 +46,7 @@ class ComputerListProcessWindowsTool(ComputerBaseTool):
         )
 
     def __call__(self, process_id: int) -> str:
+        process_id = int(process_id)
         get_window_list_result = self.agent_os.get_window_list(process_id)
         return (
             f"The Process ID: {process_id} has the"

--- a/src/askui/tools/store/computer/experimental/window_management/list_process_windows.py
+++ b/src/askui/tools/store/computer/experimental/window_management/list_process_windows.py
@@ -46,6 +46,9 @@ class ComputerListProcessWindowsTool(ComputerBaseTool):
         )
 
     def __call__(self, process_id: int) -> str:
+        # the agent occassionally calls this tool with a string i/o an int
+        # this would lead to a tool error. to prevent this, we will convert to int
+        # manually here
         process_id = int(process_id)
         get_window_list_result = self.agent_os.get_window_list(process_id)
         return (


### PR DESCRIPTION
fix: add auto-conversion of process_id param to int, to prevent tool error when agent calls it with str