### PR TITLE
Feat/tool result image scaling

### DIFF
--- a/docs/07_tools.md
+++ b/docs/07_tools.md
@@ -181,6 +181,18 @@ A tool’s __call__ method may return:
 - None
 - a list or tuple containing any of the above
 
+**Image size limit:** When a tool returns a `PIL.Image.Image`, it is the tool’s responsibility to ensure the image does not exceed **2000×2000 px** (longest side ≤ 2000 px). The Claude API enforces a 2000×2000 px per-image limit when more than 20 images are sent in a single request, which is common in agentic loops. Use `downscale_image()` from `askui.utils.image_utils` to downscale images that may be too large:
+
+```python
+from PIL import Image
+from askui.utils.image_utils import downscale_image
+
+image: Image.Image = ...  # your image
+image = downscale_image(image, max_dimension=2000)
+```
+
+This preserves the original aspect ratio and only downscales images whose longest side exceeds the limit.
+
 ### Complete Example
 
 Here’s a greeting tool that demonstrates all the key concepts:

--- a/src/askui/models/shared/tools.py
+++ b/src/askui/models/shared/tools.py
@@ -33,7 +33,7 @@ from askui.models.shared.agent_message_param import (
 )
 from askui.tools import AgentOs
 from askui.tools.android.agent_os import AndroidAgentOs
-from askui.utils.image_utils import ImageSource, base64_to_image, downscale_image
+from askui.utils.image_utils import ImageSource, base64_to_image
 
 logger = logging.getLogger(__name__)
 
@@ -100,10 +100,6 @@ def _convert_to_content(
     if isinstance(result, BaseModel):
         return [TextBlockParam(text=result.model_dump_json())]
 
-    # Downscale to stay within the 2000x2000 px per-image limit that applies
-    # when more than 20 images are sent in a single API request (Claude API).
-    # https://platform.claude.com/docs/en/build-with-claude/vision#before-you-upload
-    result = downscale_image(result, max_dimension=2000)
     return [
         ImageBlockParam(
             source=Base64ImageSourceParam(

--- a/src/askui/models/shared/tools.py
+++ b/src/askui/models/shared/tools.py
@@ -33,7 +33,7 @@ from askui.models.shared.agent_message_param import (
 )
 from askui.tools import AgentOs
 from askui.tools.android.agent_os import AndroidAgentOs
-from askui.utils.image_utils import ImageSource, base64_to_image, downscale_image
+from askui.utils.image_utils import ImageSource, base64_to_image
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +103,9 @@ def _convert_to_content(
     # Downscale to stay within the 2000x2000 px per-image limit that applies
     # when more than 20 images are sent in a single API request (Claude API).
     # https://platform.claude.com/docs/en/build-with-claude/vision#before-you-upload
-    result = downscale_image(result, max_dimension=2000)
+    # NOTE: downscaling is a responsibility of the tools themselves!
+    # Hence, we will not do it here anymore!
+    # result = downscale_image(result, max_dimension=2000)
     return [
         ImageBlockParam(
             source=Base64ImageSourceParam(

--- a/src/askui/models/shared/tools.py
+++ b/src/askui/models/shared/tools.py
@@ -33,7 +33,7 @@ from askui.models.shared.agent_message_param import (
 )
 from askui.tools import AgentOs
 from askui.tools.android.agent_os import AndroidAgentOs
-from askui.utils.image_utils import ImageSource, base64_to_image
+from askui.utils.image_utils import ImageSource, base64_to_image, downscale_image
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +100,10 @@ def _convert_to_content(
     if isinstance(result, BaseModel):
         return [TextBlockParam(text=result.model_dump_json())]
 
+    # Downscale to stay within the 2000x2000 px per-image limit that applies
+    # when more than 20 images are sent in a single API request (Claude API).
+    # https://platform.claude.com/docs/en/build-with-claude/vision#before-you-upload
+    result = downscale_image(result, max_dimension=2000)
     return [
         ImageBlockParam(
             source=Base64ImageSourceParam(

--- a/src/askui/models/shared/tools.py
+++ b/src/askui/models/shared/tools.py
@@ -33,7 +33,7 @@ from askui.models.shared.agent_message_param import (
 )
 from askui.tools import AgentOs
 from askui.tools.android.agent_os import AndroidAgentOs
-from askui.utils.image_utils import ImageSource, base64_to_image
+from askui.utils.image_utils import ImageSource, base64_to_image, downscale_image
 
 logger = logging.getLogger(__name__)
 
@@ -103,9 +103,7 @@ def _convert_to_content(
     # Downscale to stay within the 2000x2000 px per-image limit that applies
     # when more than 20 images are sent in a single API request (Claude API).
     # https://platform.claude.com/docs/en/build-with-claude/vision#before-you-upload
-    # NOTE: downscaling is a responsibility of the tools themselves!
-    # Hence, we will not do it here anymore!
-    # result = downscale_image(result, max_dimension=2000)
+    result = downscale_image(result, max_dimension=2000)
     return [
         ImageBlockParam(
             source=Base64ImageSourceParam(

--- a/src/askui/utils/image_utils.py
+++ b/src/askui/utils/image_utils.py
@@ -227,6 +227,33 @@ def scale_image_to_fit(
     return _center_image_in_background(scaled_image, target_size)
 
 
+def downscale_image(
+    image: Image.Image,
+    max_dimension: int = 2000,
+) -> Image.Image:
+    """Downscale an image so its longest side does not exceed `max_dimension`.
+
+    Preserves the original aspect ratio. Images that are already
+    within the limit are returned unchanged.
+
+    Args:
+        image (Image.Image): The PIL Image to downscale.
+        max_dimension (int, optional): Maximum allowed size for the longest side. Defaults to `2000`.
+
+    Returns:
+        Image.Image: The downscaled image, or the original if no scaling was needed.
+    """
+    longest_side = max(image.width, image.height)
+    if longest_side <= max_dimension:
+        return image
+    scale_factor = max_dimension / longest_side
+    new_size = (
+        int(image.width * scale_factor),
+        int(image.height * scale_factor),
+    )
+    return image.resize(new_size, Image.Resampling.LANCZOS)
+
+
 def _scale_coordinates(
     coordinates: tuple[int, int],
     offset: tuple[int, int],


### PR DESCRIPTION
Background:
anthropic imposes a maximum image size of 2000x2000px for images if we have more than 20 images in the message history.

We need to discuss if we want to handle downwscaling here for all tool result images that are too large or if we want to have this as a tool responsibility!

Either way, we need to add a method to image utils that can be used by tools or our sdk to downscale the image outputs.