### PR TITLE
feat: add scratch_act.py to demonstrate ComputerAgent functionality

### DIFF
--- a/scratch_act.py
+++ b/scratch_act.py
@@ -1,0 +1,4 @@
+from askui import ComputerAgent
+
+with ComputerAgent() as agent:
+    agent.act("Open askui.com on chrome browser")

--- a/src/askui/computer_agent.py
+++ b/src/askui/computer_agent.py
@@ -13,9 +13,7 @@ from askui.models.models import Point
 from askui.models.shared.settings import ActSettings, LocateSettings, MessageSettings
 from askui.models.shared.tools import Tool
 from askui.models.shared.truncation_strategies import TruncationStrategy
-from askui.prompts.act_prompts import (
-    create_computer_agent_prompt,
-)
+from askui.prompts.act_prompts import create_computer_agent_prompt
 from askui.tools.computer import (
     ComputerGetMousePositionTool,
     ComputerGetSystemInfoTool,
@@ -139,7 +137,7 @@ class ComputerAgent(Agent):
         self.act_settings = ActSettings(
             messages=MessageSettings(
                 system=create_computer_agent_prompt(),
-                thinking={"type": "enabled", "budget_tokens": 2048},
+                thinking={"type": "adaptive"},
             )
         )
 


### PR DESCRIPTION
It updates the `thinking` configuration in `ComputerAgent` to use an adaptive strategy. Should be changed for non claude-5 models.

tested with changing env variable "VLM_PROVIDER_MODEL_ID" to "claude-sonnet-5", "gemini-3.5-flash"