### PR TITLE
feat: support adaptive thinking config (Sonnet 5 and newer models)

### DIFF
--- a/src/askui/computer_agent.py
+++ b/src/askui/computer_agent.py
@@ -11,6 +11,7 @@ from askui.container import telemetry
 from askui.locators.locators import Locator
 from askui.models.models import Point
 from askui.models.shared.settings import ActSettings, LocateSettings, MessageSettings
+from askui.models.shared.thinking import make_thinking_settings
 from askui.models.shared.tools import Tool
 from askui.models.shared.truncation_strategies import TruncationStrategy
 from askui.prompts.act_prompts import (
@@ -139,7 +140,7 @@ class ComputerAgent(Agent):
         self.act_settings = ActSettings(
             messages=MessageSettings(
                 system=create_computer_agent_prompt(),
-                thinking={"type": "enabled", "budget_tokens": 2048},
+                **make_thinking_settings(self._vlm_provider.model_id),
             )
         )
 

--- a/src/askui/models/anthropic/messages_api.py
+++ b/src/askui/models/anthropic/messages_api.py
@@ -13,6 +13,7 @@ from anthropic.types.beta import (
     BetaCacheControlEphemeralParam,
     BetaContentBlockParam,
     BetaMessageParam,
+    BetaOutputConfigParam,
     BetaThinkingConfigParam,
     BetaToolChoiceParam,
     BetaToolUnionParam,
@@ -113,6 +114,7 @@ def _parse_to_anthropic_types(
     cache_control: CacheControlEphemeralParam | None = None,
     system: SystemPrompt | None = None,
     thinking: ThinkingConfigParam | None = None,
+    output_config: dict[str, Any] | None = None,
     tool_choice: ToolChoiceParam | None = None,
     temperature: float | None = None,
 ) -> Tuple[
@@ -121,6 +123,7 @@ def _parse_to_anthropic_types(
     BetaCacheControlEphemeralParam | Omit,
     str | Omit,
     BetaThinkingConfigParam | Omit,
+    BetaOutputConfigParam | Omit,
     BetaToolChoiceParam | Omit,
     float | Omit,
 ]:
@@ -149,6 +152,13 @@ def _parse_to_anthropic_types(
     _thinking = (
         cast("BetaThinkingConfigParam", thinking) if thinking is not None else omit
     )
+    # `output_config` carries `effort` (the string replacement for the integer
+    # `budget_tokens` used by older models) on models with adaptive thinking.
+    _output_config = (
+        cast("BetaOutputConfigParam", output_config)
+        if output_config is not None
+        else omit
+    )
     _tool_choice = (
         cast("BetaToolChoiceParam", tool_choice) if tool_choice is not None else omit
     )
@@ -160,6 +170,7 @@ def _parse_to_anthropic_types(
         _cache_control,
         _system,
         _thinking,
+        _output_config,
         _tool_choice,
         _temperature,
     )
@@ -196,12 +207,14 @@ class AnthropicMessagesApi(MessagesApi):
         # convert each message to anthropic BetaMessageParam type
         _messages = [from_message_param(message) for message in messages]
 
-        # Extract betas from provider_options
+        # Extract Anthropic-specific options from provider_options
         betas: list[str] | None = None
         cache_control: CacheControlEphemeralParam | None = None
+        output_config: dict[str, Any] | None = None
         if provider_options is not None:
             betas = provider_options.get("betas")
             cache_control = provider_options.get("cache_control")
+            output_config = provider_options.get("output_config")
 
         (
             _tools,
@@ -209,10 +222,18 @@ class AnthropicMessagesApi(MessagesApi):
             _cache_control,
             _system,
             _thinking,
+            _output_config,
             _tool_choice,
             _temperature,
         ) = _parse_to_anthropic_types(
-            tools, betas, cache_control, system, thinking, tool_choice, temperature
+            tools,
+            betas,
+            cache_control,
+            system,
+            thinking,
+            output_config,
+            tool_choice,
+            temperature,
         )
 
         response = self._client.beta.messages.create(  # type: ignore[misc]
@@ -224,6 +245,7 @@ class AnthropicMessagesApi(MessagesApi):
             betas=_betas,
             system=_system,
             thinking=_thinking,
+            output_config=_output_config,
             tool_choice=_tool_choice,
             temperature=_temperature,
             timeout=300.0,

--- a/src/askui/models/shared/agent_message_param.py
+++ b/src/askui/models/shared/agent_message_param.py
@@ -114,6 +114,13 @@ ThinkingConfigParam = dict[str, Any]
 ToolChoiceParam = dict[str, Any]
 ToolParam = dict[str, Any]
 
+# Effort controls how much the model thinks and acts on newer models that use
+# adaptive thinking (`thinking={"type": "adaptive"}`). It replaces the integer
+# `budget_tokens` used with `thinking={"type": "enabled", ...}` on older models.
+# Anthropic maps this to `output_config.effort`; providers that do not support
+# it (e.g. OpenAI chat) ignore it.
+EffortLevel = Literal["low", "medium", "high", "max"]
+
 
 class UsageParam(BaseModel):
     """Token usage statistics from model API calls."""
@@ -150,4 +157,5 @@ __all__ = [
     "UsageParam",
     "ThinkingConfigParam",
     "ToolChoiceParam",
+    "EffortLevel",
 ]

--- a/src/askui/models/shared/thinking.py
+++ b/src/askui/models/shared/thinking.py
@@ -1,0 +1,93 @@
+"""Model-aware defaults for thinking configuration.
+
+Lives in ``models.shared`` because it is used by the provider-agnostic agents
+(computer, web, ...), which may run on any provider. The known model families are
+currently Anthropic-only; branches for other providers (Gemini, OpenAI,
+open-source, ...) can be added here as they gain thinking controls.
+
+Anthropic changed how thinking is configured across model generations:
+
+- **Older models** (e.g. Claude Sonnet 4, Sonnet 4.5, Opus 4.1/4.5, Haiku 4.5)
+  use a fixed integer token budget: ``{"type": "enabled", "budget_tokens": N}``.
+- **Newer models** (e.g. Claude Sonnet 4.6, Sonnet 5, Opus 4.6/4.7/4.8, Fable 5)
+  use *adaptive* thinking (``{"type": "adaptive"}``) and control depth with the
+  string ``effort`` instead. Sending ``budget_tokens`` to these models is
+  rejected, and ``effort`` is a separate parameter sent via
+  ``output_config.effort`` (not part of ``thinking``).
+
+`make_thinking_settings()` returns the `MessageSettings` keyword arguments that
+enable thinking for a given ``model_id``, so agents can turn thinking on by
+default without knowing which generation they run on. Callers can still override
+`thinking` (and `provider_options`) explicitly.
+"""
+
+from typing import Any
+
+from askui.models.shared.agent_message_param import EffortLevel
+
+_DEFAULT_BUDGET_TOKENS = 2048
+
+# Model-ID prefixes for Anthropic models that use adaptive thinking. These are
+# the models where the integer `budget_tokens` is removed or deprecated in favour
+# of adaptive thinking (`{"type": "adaptive"}`) plus the `effort` setting.
+# `str.startswith` matches dated snapshots too (e.g. "claude-sonnet-4-6-20260401").
+# Note: "claude-sonnet-5" does not match the older "claude-sonnet-4-5".
+_ADAPTIVE_THINKING_MODEL_PREFIXES = (
+    "claude-sonnet-4-6",
+    "claude-sonnet-5",
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-opus-5",
+    "claude-fable-5",
+)
+
+
+def uses_adaptive_thinking(model_id: str) -> bool:
+    """Whether ``model_id`` uses adaptive thinking instead of a token budget.
+
+    Args:
+        model_id (str): The Anthropic model identifier.
+
+    Returns:
+        bool: ``True`` if the model expects ``{"type": "adaptive"}`` and the
+            `effort` setting, ``False`` if it expects a fixed ``budget_tokens``.
+    """
+    return model_id.startswith(_ADAPTIVE_THINKING_MODEL_PREFIXES)
+
+
+def make_thinking_settings(
+    model_id: str,
+    effort: EffortLevel | None = None,
+) -> dict[str, Any]:
+    """Return `MessageSettings` keyword arguments enabling thinking for a model.
+
+    Splat the result into `MessageSettings` alongside any other fields, e.g.::
+
+        MessageSettings(
+            system=create_computer_agent_prompt(),
+            **make_thinking_settings(self._vlm_provider.model_id),
+        )
+
+    Models that support adaptive thinking get ``thinking={"type": "adaptive"}``
+    (with ``effort`` sent via ``provider_options["output_config"]`` when given);
+    older models get a fixed token budget of
+    ``thinking={"type": "enabled", "budget_tokens": 2048}`` and ignore ``effort``.
+
+    Args:
+        model_id (str): The Anthropic model identifier.
+        effort (EffortLevel | None, optional): How much the model should think and
+            act (``"low"``, ``"medium"``, ``"high"`` or ``"max"``). Only applied
+            for models that support adaptive thinking. Default: None (the model
+            uses its own default).
+
+    Returns:
+        dict[str, Any]: `MessageSettings` keyword arguments (``thinking`` and,
+            when applicable, ``provider_options``).
+    """
+    if uses_adaptive_thinking(model_id):
+        settings: dict[str, Any] = {"thinking": {"type": "adaptive"}}
+        if effort is not None:
+            settings["provider_options"] = {"output_config": {"effort": effort}}
+        return settings
+    return {"thinking": {"type": "enabled", "budget_tokens": _DEFAULT_BUDGET_TOKENS}}

--- a/src/askui/web_agent.py
+++ b/src/askui/web_agent.py
@@ -10,6 +10,7 @@ from askui.models.shared.settings import (
     ActSettings,
     MessageSettings,
 )
+from askui.models.shared.thinking import make_thinking_settings
 from askui.models.shared.tools import Tool
 from askui.models.shared.truncation_strategies import TruncationStrategy
 from askui.prompts.act_prompts import create_web_agent_prompt
@@ -78,7 +79,7 @@ class WebAgent(Agent):
         self.act_settings = ActSettings(
             messages=MessageSettings(
                 system=create_web_agent_prompt(),
-                thinking={"type": "enabled", "budget_tokens": 2048},
+                **make_thinking_settings(self._vlm_provider.model_id),
             ),
         )
 

--- a/src/askui/web_testing_agent.py
+++ b/src/askui/web_testing_agent.py
@@ -7,6 +7,7 @@ from askui.models.shared.settings import (
     ActSettings,
     MessageSettings,
 )
+from askui.models.shared.thinking import make_thinking_settings
 from askui.prompts.act_prompts import create_web_agent_prompt
 from askui.tools.testing.execution_tools import (
     CreateExecutionTool,
@@ -70,6 +71,6 @@ class WebTestingAgent(WebVisionAgent):
         self.act_settings = ActSettings(
             messages=MessageSettings(
                 system=create_web_agent_prompt(),
-                thinking={"type": "enabled", "budget_tokens": 2048},
+                **make_thinking_settings(self._vlm_provider.model_id),
             ),
         )

--- a/tests/unit/models/anthropic/test_messages_api.py
+++ b/tests/unit/models/anthropic/test_messages_api.py
@@ -1,0 +1,70 @@
+"""Unit tests for Anthropic messages API output_config / thinking handling."""
+
+from unittest.mock import MagicMock
+
+from anthropic import omit
+
+from askui.models.anthropic.messages_api import (
+    AnthropicMessagesApi,
+    _parse_to_anthropic_types,
+)
+from askui.models.shared.agent_message_param import MessageParam
+
+
+class TestParseToAnthropicTypes:
+    """`output_config` (carrying `effort`) is forwarded, or omitted when absent."""
+
+    def test_output_config_passed_through(self) -> None:
+        result = _parse_to_anthropic_types(tools=None, output_config={"effort": "high"})
+        assert result[5] == {"effort": "high"}
+
+    def test_no_output_config_is_omitted(self) -> None:
+        result = _parse_to_anthropic_types(tools=None, output_config=None)
+        assert result[5] is omit
+
+    def test_adaptive_thinking_passed_through(self) -> None:
+        result = _parse_to_anthropic_types(tools=None, thinking={"type": "adaptive"})
+        assert result[4] == {"type": "adaptive"}
+
+
+class TestCreateMessage:
+    """`create_message` reads output_config from provider_options."""
+
+    def _make_api(self) -> tuple[AnthropicMessagesApi, MagicMock]:
+        client = MagicMock()
+        response = MagicMock()
+        response.model_dump.return_value = {
+            "role": "assistant",
+            "content": "hello",
+        }
+        client.beta.messages.create.return_value = response
+        return AnthropicMessagesApi(client=client), client
+
+    def test_effort_from_provider_options_forwarded(self) -> None:
+        api, client = self._make_api()
+
+        result = api.create_message(
+            messages=[MessageParam(role="user", content="hi")],
+            model_id="claude-sonnet-5",
+            thinking={"type": "adaptive"},
+            provider_options={"output_config": {"effort": "medium"}},
+        )
+
+        assert isinstance(result, MessageParam)
+        kwargs = client.beta.messages.create.call_args.kwargs
+        assert kwargs["model"] == "claude-sonnet-5"
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert kwargs["output_config"] == {"effort": "medium"}
+
+    def test_no_output_config_omits_it(self) -> None:
+        api, client = self._make_api()
+
+        api.create_message(
+            messages=[MessageParam(role="user", content="hi")],
+            model_id="claude-sonnet-4-5-20250929",
+            thinking={"type": "enabled", "budget_tokens": 2048},
+        )
+
+        kwargs = client.beta.messages.create.call_args.kwargs
+        assert kwargs["output_config"] is omit
+        assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 2048}

--- a/tests/unit/models/test_thinking.py
+++ b/tests/unit/models/test_thinking.py
@@ -1,0 +1,64 @@
+"""Unit tests for model-aware thinking defaults."""
+
+import pytest
+
+from askui.models.shared.thinking import (
+    make_thinking_settings,
+    uses_adaptive_thinking,
+)
+
+_ADAPTIVE_MODELS = [
+    "claude-sonnet-5",
+    "claude-sonnet-5-20260601",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-6-20260401",
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-opus-5",
+    "claude-fable-5",
+]
+
+_BUDGET_MODELS = [
+    "claude-sonnet-4-5-20250929",
+    "claude-sonnet-4-20250514",
+    "claude-opus-4-5-20251101",
+    "claude-opus-4-1-20250805",
+    "claude-haiku-4-5-20251001",
+    "gpt-5.4",
+    "some-unknown-model",
+]
+
+
+@pytest.mark.parametrize("model_id", _ADAPTIVE_MODELS)
+def test_adaptive_models_use_adaptive_thinking(model_id: str) -> None:
+    assert uses_adaptive_thinking(model_id) is True
+    assert make_thinking_settings(model_id) == {"thinking": {"type": "adaptive"}}
+
+
+@pytest.mark.parametrize("model_id", _BUDGET_MODELS)
+def test_other_models_use_budget_tokens(model_id: str) -> None:
+    assert uses_adaptive_thinking(model_id) is False
+    assert make_thinking_settings(model_id) == {
+        "thinking": {"type": "enabled", "budget_tokens": 2048}
+    }
+
+
+def test_effort_is_added_via_provider_options_for_adaptive_models() -> None:
+    assert make_thinking_settings("claude-sonnet-5", effort="high") == {
+        "thinking": {"type": "adaptive"},
+        "provider_options": {"output_config": {"effort": "high"}},
+    }
+
+
+def test_effort_is_ignored_for_budget_models() -> None:
+    # Older models do not support `effort`; it must not leak into the settings.
+    assert make_thinking_settings("claude-sonnet-4-5-20250929", effort="high") == {
+        "thinking": {"type": "enabled", "budget_tokens": 2048}
+    }
+
+
+def test_sonnet_5_is_not_confused_with_sonnet_4_5() -> None:
+    # "claude-sonnet-5" must not match the older "claude-sonnet-4-5" prefix.
+    assert uses_adaptive_thinking("claude-sonnet-5") is True
+    assert uses_adaptive_thinking("claude-sonnet-4-5") is False


### PR DESCRIPTION
## What

Adds support for the newer Anthropic model generation (e.g. `sonnet-5`, `sonnet-4-6`, `opus-4.6+`, `fable-5`), which replaced the integer `budget_tokens` thinking control with **adaptive thinking** (`{"type": "adaptive"}`) plus a string **`effort`** knob. Sending `budget_tokens` to these models is rejected, so the previous hardcoded default would 400.

## How

Kept the change minimal and provider-neutral:

- **`models/shared/thinking.py`** (new) — `make_thinking_settings(model_id, effort=None)` returns the model-appropriate `MessageSettings` kwargs: adaptive thinking for newer models (with optional `effort`), the fixed `budget_tokens=2048` for older ones. Lives in `models.shared` so it can grow branches for other providers (Gemini, OpenAI, …) later.
- **`models/anthropic/messages_api.py`** — reads `output_config` (carrying `effort`) out of `provider_options`, next to where `betas`/`cache_control` are already extracted. No `create_message` signature changes.
- **Computer / Web / WebTesting agents** — use `make_thinking_settings(self._vlm_provider.model_id)` instead of hardcoding `budget_tokens`.
- **`agent_message_param.py`** — adds the `EffortLevel` string literal type.

The default model (`claude-sonnet-4-6`) is adaptive-capable, so the default agents now send adaptive thinking instead of the deprecated `budget_tokens`. Older models a user selects explicitly keep the fixed budget automatically.

## Tests

- `tests/unit/models/test_thinking.py` — model-aware defaults, effort via `provider_options`, and `sonnet-5` not being confused with `sonnet-4-5`.
- `tests/unit/models/anthropic/test_messages_api.py` — `output_config` forwarding / omission and adaptive passthrough.

All unit tests pass; `mypy` and `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)