### PR TITLE
fix: complete browser downloads before teardown instead of truncating

### DIFF
--- a/src/askui/tools/playwright/agent_os.py
+++ b/src/askui/tools/playwright/agent_os.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import subprocess
+import threading
 from pathlib import Path
 from typing import Literal
 
@@ -29,6 +30,19 @@ from ..agent_os import (
     ModifierKey,
     PcKey,
 )
+
+
+class DownloadError(RuntimeError):
+    """Raised when one or more browser downloads could not be saved completely.
+
+    Surfaced instead of leaving silently truncated files on disk (e.g. when a
+    download is still being copied while the browser is torn down).
+    """
+
+
+# Time to pump the Playwright event loop so a download that started right
+# before teardown surfaces its ``download`` event before the queue is drained.
+_DOWNLOAD_EVENT_GRACE_S = 0.1
 
 
 def _to_unique_path(path: Path) -> Path:
@@ -116,8 +130,15 @@ class PlaywrightAgentOs(ComputerAgentOS):
         self._listening = False
         self._event_queue: list[InputEvent] = []
 
-        # Files copied into `download_dir`, in the order they finished
+        # Download tracking state. `_pending_downloads` holds downloads whose
+        # copy has not run yet; they are drained on the main thread (never
+        # inside the event callback) so the copy runs deterministically and is
+        # awaited before the browser is torn down. `_download_errors` collects
+        # failures so they can be surfaced instead of leaving truncated files.
+        self._download_lock = threading.Lock()
+        self._pending_downloads: list[Download] = []
         self._downloaded_files: list[Path] = []
+        self._download_errors: list[str] = []
 
     def _install_playwright_browser(self) -> None:
         """Install Playwright browser if requested."""
@@ -213,37 +234,119 @@ class PlaywrightAgentOs(ComputerAgentOS):
         )
 
     def _on_download(self, download: Download) -> None:
-        """Copy a finished download into `download_dir`.
+        """Register a started download for deterministic saving.
 
-        Registered as the page's ``download`` event handler. When `download_dir`
-        is configured, the file is saved there under its suggested filename
-        (auto-renamed on collision); otherwise the download is left untouched in
-        Playwright's temporary location. Failures are reported but never
-        propagated, so a failed download cannot break the automation run.
+        Registered as the page's ``download`` event handler. The download is
+        only recorded here; the actual copy runs in `_flush_downloads` on the
+        main thread. Calling the blocking `save_as` from inside this sync-API
+        event callback is not guaranteed to run to completion, which truncated
+        large files when the browser was closed mid-copy.
 
         Args:
             download (Download): The Playwright download to persist.
         """
         if self._download_dir is None:
             return
+        with self._download_lock:
+            self._pending_downloads.append(download)
+        self._reporter.add_message(
+            self._REPORTER_ROLE_NAME,
+            f"Download started: '{Path(download.suggested_filename).name}'",
+        )
+
+    def _pump_event_loop(self, seconds: float) -> None:
+        """Pump the Playwright event loop for ``seconds``.
+
+        Lets queued events (such as a just-started ``download``) be delivered
+        to their handlers. Best effort: swallows errors as the page may already
+        be closing.
+        """
+        if self._page is None:
+            return
+        try:
+            self._page.wait_for_timeout(seconds * 1000)
+        except Exception:  # noqa: BLE001 - best effort; page may be closing
+            pass
+
+    def _deliver_and_flush_downloads(self) -> None:
+        """Deliver any just-started download events, then save all downloads.
+
+        Used at points where no other Playwright call is pumping the event loop
+        (teardown and the explicit wait), so a download triggered by the last
+        action is not missed.
+        """
+        if self._download_dir is None:
+            return
+        self._pump_event_loop(_DOWNLOAD_EVENT_GRACE_S)
+        self._flush_downloads()
+
+    def _flush_downloads(self) -> None:
+        """Copy all pending downloads into `download_dir`, blocking until done.
+
+        Runs on the main (Playwright) thread. Each failure is collected in
+        `_download_errors` rather than raised here, so a single failing download
+        neither aborts the remaining ones nor the teardown of other resources.
+        """
+        if self._download_dir is None:
+            return
+        with self._download_lock:
+            pending = self._pending_downloads
+            self._pending_downloads = []
+        for download in pending:
+            self._save_download(download)
+
+    def _save_download(self, download: Download) -> None:
+        assert self._download_dir is not None
         # Use only the filename component to avoid path traversal from a
         # server-suggested name such as "../../etc/passwd".
         suggested_name = Path(download.suggested_filename).name
         target = _to_unique_path(self._download_dir / suggested_name)
         try:
             target.parent.mkdir(parents=True, exist_ok=True)
+            # `save_as` blocks until the download has fully finished and been
+            # copied to `target`, so running it here (on the main thread, before
+            # teardown) guarantees a complete file.
             download.save_as(target)
-        except Exception as e:  # noqa: BLE001 - never let a download break the run
-            self._reporter.add_message(
-                self._REPORTER_ROLE_NAME,
-                f"Failed to save download '{suggested_name}': {e}",
-            )
+        except Exception as e:  # noqa: BLE001 - collect, don't let one break the run
+            # Do not leave a partially written file masquerading as a complete
+            # download; remove it and surface the failure.
+            target.unlink(missing_ok=True)
+            error_msg = f"Failed to save download '{suggested_name}': {e}"
+            self._download_errors.append(error_msg)
+            self._reporter.add_message(self._REPORTER_ROLE_NAME, error_msg)
             return
         self._downloaded_files.append(target)
         self._reporter.add_message(
             self._REPORTER_ROLE_NAME,
             f"Downloaded file saved to {target}",
         )
+
+    def wait_until_downloads_complete(self) -> list[Path]:
+        """Block until all downloads started so far are fully saved to disk.
+
+        `save_as` blocks until each download has finished, so callers can use
+        this to obtain complete files mid-run without having to keep the
+        Playwright event loop alive themselves.
+
+        Returns:
+            list[Path]: Absolute paths of all downloads saved so far this
+                session.
+
+        Raises:
+            DownloadError: If one or more downloads could not be saved
+                completely.
+        """
+        self._deliver_and_flush_downloads()
+        self._raise_download_errors()
+        return list(self._downloaded_files)
+
+    def _raise_download_errors(self) -> None:
+        if not self._download_errors:
+            return
+        errors = self._download_errors
+        self._download_errors = []
+        error_msg = "Failed to complete downloads:\n" + "\n".join(errors)
+        raise DownloadError(error_msg)
 
     @property
     def downloaded_files(self) -> list[Path]:
@@ -258,9 +361,24 @@ class PlaywrightAgentOs(ComputerAgentOS):
 
     @override
     def disconnect(self) -> None:
-        """Terminates the connection to the browser."""
+        """Terminates the connection to the browser.
+
+        Any download triggered during the run is written to `download_dir`
+        completely before the page/context/browser is closed. If a download
+        cannot be saved, its partial file is removed and a `DownloadError` is
+        raised after teardown instead of leaving a silently truncated file.
+
+        Raises:
+            DownloadError: If one or more downloads could not be saved
+                completely.
+        """
         if self._listening:
             self.stop_listening()
+
+        # Drain in-flight downloads while the page/context/browser are still
+        # alive so `save_as` can run to completion. Otherwise Playwright aborts
+        # the copy and leaves a truncated file on disk.
+        self._deliver_and_flush_downloads()
 
         if self._page:
             self._page.close()
@@ -283,6 +401,8 @@ class PlaywrightAgentOs(ComputerAgentOS):
             "Disconnected from playwright os",
         )
 
+        self._raise_download_errors()
+
     @override
     def screenshot(self, report: bool = True, unscaled: bool = False) -> Image.Image:
         """Capture a screenshot of the current page.
@@ -303,6 +423,11 @@ class PlaywrightAgentOs(ComputerAgentOS):
 
         screenshot_bytes = self._page.screenshot(scale="css")
         screenshot = Image.open(io.BytesIO(screenshot_bytes))
+        # Taking the screenshot pumps the event loop, so any download that
+        # started since the last interaction has now surfaced its event.
+        # Persist it so it is available to the caller during the run, not only
+        # at teardown.
+        self._flush_downloads()
         if report:
             self._reporter.add_message(
                 self._REPORTER_ROLE_NAME, "screenshot()", screenshot

--- a/src/askui/web_agent.py
+++ b/src/askui/web_agent.py
@@ -126,6 +126,19 @@ class WebAgent(Agent):
             ),
         )
 
+    def wait_until_downloads_complete(self) -> list[Path]:
+        """Block until all downloads started so far are fully saved to disk.
+
+        Returns:
+            list[Path]: Absolute paths of all downloads saved to `download_dir`
+                so far this session.
+
+        Raises:
+            DownloadError: If one or more downloads could not be saved
+                completely.
+        """
+        return self.os.wait_until_downloads_complete()
+
     @staticmethod
     def get_default_tools() -> list[Tool]:
         return [

--- a/tests/e2e/tools/playwright/test_download.py
+++ b/tests/e2e/tools/playwright/test_download.py
@@ -1,14 +1,35 @@
+import hashlib
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import Any
 
 import pytest
+from playwright.sync_api import Download
+from pytest_mock import MockerFixture
 
-from askui.tools.playwright.agent_os import PlaywrightAgentOs
+from askui.tools.playwright.agent_os import DownloadError, PlaywrightAgentOs
 
 # A page with a link that downloads a small text file via a data URL. The
 # ``download`` attribute makes the browser treat the navigation as a download
 # and provides the suggested filename.
 _DOWNLOAD_PAGE = (
     '<a id="dl" download="sample.txt" href="data:text/plain,Hello%20AskUI">download</a>'
+)
+
+# A file large enough that Playwright streams the artifact in multiple chunks,
+# so a truncated save (the bug guarded against here) would cut it at a MiB
+# boundary rather than producing a complete file.
+_LARGE_FILE_SIZE = 20 * 1024 * 1024
+_LARGE_FILE_NAME = "large.bin"
+_LARGE_PAYLOAD = bytes((i * 2654435761) & 0xFF for i in range(_LARGE_FILE_SIZE))
+_LARGE_PAYLOAD_SHA256 = hashlib.sha256(_LARGE_PAYLOAD).hexdigest()
+
+_LARGE_DOWNLOAD_PAGE = (
+    b"<html><body>"
+    b'<a id="dl" href="/' + _LARGE_FILE_NAME.encode() + b'" download>Download</a>'
+    b"</body></html>"
 )
 
 
@@ -19,6 +40,55 @@ def _trigger_download(agent_os: PlaywrightAgentOs) -> None:
     page.click("#dl")
     # Give the download event time to fire and the file to be written.
     page.wait_for_timeout(2000)
+
+
+class _LargeDownloadHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(_LARGE_DOWNLOAD_PAGE)))
+            self.end_headers()
+            self.wfile.write(_LARGE_DOWNLOAD_PAGE)
+            return
+
+        if self.path == f"/{_LARGE_FILE_NAME}":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header(
+                "Content-Disposition",
+                f'attachment; filename="{_LARGE_FILE_NAME}"',
+            )
+            self.send_header("Content-Length", str(len(_LARGE_PAYLOAD)))
+            self.end_headers()
+            self.wfile.write(_LARGE_PAYLOAD)
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        """Silence the default stderr request logging."""
+
+
+@pytest.fixture
+def large_download_server() -> Iterator[str]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _LargeDownloadHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        port = server.socket.getsockname()[1]
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def _trigger_large_download(agent_os: PlaywrightAgentOs, base_url: str) -> None:
+    agent_os.goto(base_url + "/")
+    page = agent_os._page
+    assert page is not None
+    page.click("#dl")
 
 
 @pytest.mark.timeout(60)
@@ -69,3 +139,67 @@ def test_no_download_dir_leaves_files_in_temp(tmp_path: Path) -> None:
 
     assert agent_os.downloaded_files == []
     assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.timeout(60)
+def test_large_download_is_complete_after_disconnect(
+    tmp_path: Path, large_download_server: str
+) -> None:
+    agent_os = PlaywrightAgentOs(
+        headless=True, install_browser=False, download_dir=tmp_path
+    )
+    agent_os.connect()
+    _trigger_large_download(agent_os, large_download_server)
+    # End the run immediately without pumping the event loop further; the
+    # download must still be saved completely before the browser closes.
+    agent_os.disconnect()
+
+    saved = tmp_path / _LARGE_FILE_NAME
+    assert saved.exists()
+    content = saved.read_bytes()
+    assert len(content) == _LARGE_FILE_SIZE
+    assert hashlib.sha256(content).hexdigest() == _LARGE_PAYLOAD_SHA256
+
+
+@pytest.mark.timeout(60)
+def test_wait_until_downloads_complete_returns_saved_paths(
+    tmp_path: Path, large_download_server: str
+) -> None:
+    agent_os = PlaywrightAgentOs(
+        headless=True, install_browser=False, download_dir=tmp_path
+    )
+    agent_os.connect()
+    try:
+        _trigger_large_download(agent_os, large_download_server)
+        saved_paths = agent_os.wait_until_downloads_complete()
+
+        assert saved_paths == [tmp_path / _LARGE_FILE_NAME]
+        assert (tmp_path / _LARGE_FILE_NAME).read_bytes() == _LARGE_PAYLOAD
+    finally:
+        agent_os.disconnect()
+
+
+@pytest.mark.timeout(60)
+def test_failed_save_raises_and_leaves_no_partial_file(
+    tmp_path: Path, large_download_server: str, mocker: MockerFixture
+) -> None:
+    def _fail(_download: Download, path: object) -> None:
+        # Emulate Playwright aborting the copy after writing a partial file.
+        Path(str(path)).write_bytes(b"partial")
+        error_msg = "Target page, context or browser has been closed"
+        raise RuntimeError(error_msg)
+
+    mocker.patch.object(Download, "save_as", _fail)
+
+    agent_os = PlaywrightAgentOs(
+        headless=True, install_browser=False, download_dir=tmp_path
+    )
+    agent_os.connect()
+    _trigger_large_download(agent_os, large_download_server)
+
+    with pytest.raises(DownloadError):
+        agent_os.disconnect()
+
+    # The truncated partial must be removed, not left masquerading as a
+    # complete download.
+    assert list(tmp_path.glob("*")) == []


### PR DESCRIPTION
## Problem

`WebAgent(download_dir=...)` silently **truncated large downloads**. Files larger than a few MiB were frequently cut off at a whole-MiB boundary (e.g. 8/12/18 MiB for a ~22 MB zip), while small files worked. The truncation was timing-dependent and produced corrupt files (`unzip -t` → "cannot find zipfile directory") with **no error surfaced** to the caller.

## Root cause

In `PlaywrightAgentOs`, the `download` event handler called `download.save_as()` **directly inside the Playwright sync-API event callback**, where the copy is not guaranteed to run to completion. `disconnect()` then closed the page/context/browser without waiting, so an in-flight copy was aborted mid-stream (`Download.save_as: Target page, context or browser has been closed`). The exception was swallowed (`except … return`), so the run reported success over a partially-written file. The MiB-boundary sizes are the fingerprint of Playwright's 1 MiB chunked copy loop.

## Fix

- **Save on the main thread, not in the event callback.** The `download` event now only registers the download into a lock-guarded registry; the blocking `save_as` runs on the main thread where it reliably completes.
- **Await downloads before teardown.** `disconnect()` drains and finishes all downloads while the browser is still alive, before closing it. `screenshot()` also flushes pending downloads (it already pumps the event loop), so files land in `download_dir` during the run, not only at teardown.
- **Don't swallow failures.** On a failed/aborted save, the partial file is deleted and a `DownloadError` is raised from `disconnect()` / `wait_until_downloads_complete()` instead of leaving a silently truncated file.
- **New public API** `PlaywrightAgentOs.wait_until_downloads_complete()`, also exposed on `WebAgent`, so callers can await completion mid-run without keeping the event loop alive themselves.

## Tests

Extended `tests/e2e/tools/playwright/test_download.py` (serving a 20 MiB file from a local HTTP server):

- large download is **byte-for-byte complete** (size + sha256) after an immediate `disconnect()`;
- `wait_until_downloads_complete()` returns the saved paths and bytes match;
- a failed save **raises `DownloadError` and leaves no partial file**.

All 6 download e2e tests pass; `ruff` (lint + format) and `mypy` are clean.

## Acceptance criteria

- [x] ~50 MB (here 20 MiB) download yields a complete file matching source size/hash, across repeated runs
- [x] Ending the run does not truncate an in-flight download — it either completes or the failure is raised
- [x] Regression test serving a large file from a local server

🤖 Generated with [Claude Code](https://claude.com/claude-code)