### PR TITLE
chore: bump version to 0.40.0

### DIFF
--- a/src/askui/__init__.py
+++ b/src/askui/__init__.py
@@ -1,6 +1,6 @@
 """AskUI Python SDK"""
 
-__version__ = "0.39.0"
+__version__ = "0.40.0"
 
 import logging
 import os


### PR DESCRIPTION
Bumps `__version__` to `0.40.0` ahead of the release.

Includes the `display` selection feature for `AndroidAgent` (#296): `display` param (AndroidDisplay / list / index / name), optional `AndroidDisplay` ids, and `display_allow_switching`. Minor bump.

Once merged, publish the GitHub Release `v0.40.0` targeting `main` to trigger the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)