### PR TITLE
chore: bump version to 0.41.0

### DIFF
--- a/src/askui/__init__.py
+++ b/src/askui/__init__.py
@@ -1,6 +1,6 @@
 """AskUI Python SDK"""
 
-__version__ = "0.40.0"
+__version__ = "0.41.0"
 
 import logging
 import os


### PR DESCRIPTION
Bumps `__version__` to `0.41.0` ahead of the release.

Includes the OpenAI `message_transform` hook (#298), which lets OpenAI-compatible providers adapt the request payload for gateways that deviate from the stock chat spec — without monkeypatching. Minor bump.

Once merged, publish the GitHub Release `v0.41.0` targeting `main` to trigger the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)