### PR TITLE
fix: correct typos in error messages and guard empty coordinate extraction

### DIFF
--- a/src/askui/models/anthropic/utils.py
+++ b/src/askui/models/anthropic/utils.py
@@ -4,5 +4,8 @@ import re
 def extract_click_coordinates(text: str) -> tuple[int, int]:
     pattern = r"<click>(\d+),\s*(\d+)"
     matches = re.findall(pattern, text)
+    if not matches:
+        msg = f"No click coordinates found in text: {text}"
+        raise ValueError(msg)
     x, y = matches[-1]
     return int(x), int(y)

--- a/src/askui/tools/android/ppadb_agent_os.py
+++ b/src/askui/tools/android/ppadb_agent_os.py
@@ -436,7 +436,7 @@ class PpadbAgentOs(AndroidAgentOs):
         devices: list[AndroidDevice] = self._get_connected_devices()
 
         if not self._device:
-            msg = "No device is selected, did you call on of the set_device methods?"
+            msg = "No device is selected, did you call one of the set_device methods?"
             raise AndroidAgentOsError(msg)
 
         for device in devices:
@@ -447,7 +447,7 @@ class PpadbAgentOs(AndroidAgentOs):
 
     def _check_if_display_is_selected(self) -> None:
         if self._selected_display is None:
-            msg = "No display is selected, did you call on of  the set_display methods?"
+            msg = "No display is selected, did you call one of the set_display methods?"
             raise AndroidAgentOsError(msg)
 
     def _get_connected_devices(self) -> list[AndroidDevice]:


### PR DESCRIPTION
## Summary

- Fixed typo `"on of"` → `"one of"` in two error messages in `ppadb_agent_os.py` (lines 439, 450)
- Removed extra double space in the second error message  
- Added empty-match guard in `extract_click_coordinates()` in `anthropic/utils.py` to raise a clear `ValueError` instead of `IndexError` when no coordinates are found in the LLM response

## Changes

**`src/askui/tools/android/ppadb_agent_os.py`**
- Line 439: `"did you call on of the set_device methods?"` → `"did you call one of the set_device methods?"`
- Line 450: `"did you call on of  the set_display methods?"` → `"did you call one of the set_display methods?"`

**`src/askui/models/anthropic/utils.py`**
- Added check: if `re.findall()` returns no matches, raise `ValueError` with descriptive message instead of crashing with `IndexError` on `matches[-1]`

## Test plan

- [x] Verified typo fixes are correct
- [x] Verified the guard raises `ValueError` with a helpful message when no coordinates are found
- [x] No behavioral change for the happy path — when coordinates exist, function works identically